### PR TITLE
fix: default for SETTINGS_MODULE if nothing is provided.

### DIFF
--- a/saffier/conf/__init__.py
+++ b/saffier/conf/__init__.py
@@ -1,7 +1,5 @@
 import os
 
-try:
-    from dymmond_settings import settings as settings
-except ModuleNotFoundError:
+if not os.environ.get("SETTINGS_MODULE"):
     os.environ.setdefault("SETTINGS_MODULE", "saffier.conf.global_settings.SaffierSettings")
-    from dymmond_settings import settings as settings
+from dymmond_settings import settings as settings


### PR DESCRIPTION
ModuleNotFoundError is raised here: https://github.com/dymmond/dymmond-settings/blob/main/dymmond_settings/conf.py#L26-L30

You shouldn't have to catch import exceptions.

