### PR TITLE
feat: migrate database runtime to sqlalchemy async

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ programs and relational databases.
 Two of the most well known ORMs are from Django and SQLAlchemy. Both have their own strengths and
 weaknesses and specific use cases.
 
-This ORM is built on the top of SQLAlchemy core and aims to simplify the way the setup and queries
-are done into a more common and familiar interface.
+This ORM is built directly on SQLAlchemy 2.x Async and aims to simplify setup and queries into a
+more common and familiar interface.
 
 ## Before continuing
 
-Saffier is built for teams that want a direct SQLAlchemy-core-powered ORM workflow
-without introducing a Pydantic-centric architecture in the model layer.
+Saffier is built for teams that want a direct SQLAlchemy Async ORM workflow without introducing a
+Pydantic-centric architecture in the model layer.
 
 ## Why this ORM
 
@@ -75,14 +75,14 @@ When investigating for a project different types of ORMs and compared them to ea
 of use cases, SQLAlchemyalways took the win but had an issue, the async support (which now there
 are a few solutions). While doing the research I came across [Encode ORM](https://www.encode.io/orm/).
 
-The team is the same behind of Databases, Django Rest Framework, Starlette,
-httpx and a lot more tools used by millions.
+The team is the same behind Django Rest Framework, Starlette, httpx and a lot more tools used by
+millions.
 
 There was one issue though, although ORM was doing a great familiar interface with SQLAlchemy and
 providing the async solution needed, it was, by the time of this writing, incomplete and they
 even stated that in the documentation and that is how **Saffier** was born.
 
-Saffier uses some of the same concepts of ORM from Encode but rewritten in **Pydantic** but not all.
+Saffier uses some of the same concepts from Encode ORM but with its own Python-native model layer.
 
 ## Saffier
 
@@ -90,8 +90,8 @@ Saffier is some sort of a fork from [Encode ORM](https://www.encode.io/orm/) but
 core and with a complete set of tools with a familiar interface to work with.
 If you are familiar with Django, then you came for a treat 😄.
 
-Saffier leverages the power of **Pydantic** for its fields while offering a friendly, familiar and
-easy to use interface.
+Saffier provides a Python-native field system while offering a friendly, familiar and easy to use
+interface.
 
 This ORM was designed to be flexible and compatible with pretty much every ASGI framework, like
 [Esmerald](https://esmerald.dymmond.com), Starlette, FastAPI, Sanic, Quart... With simple pluggable
@@ -105,7 +105,7 @@ done by the amazing team behind it. For that reason, thank you!
 ## Features
 
 While adopting a familiar interface, it offers some cool and powerful features on the top of
-SQLAlchemy core.
+SQLAlchemy 2.x Async.
 
 ### Key features
 
@@ -131,10 +131,11 @@ And a lot more you can do here.
 
 ## Migrations
 
-Since **Saffier**, like [Encode ORM](https://www.encode.io/orm/), is built on the top of
-[SQLAlchemy core](https://docs.sqlalchemy.org/en/20/core/), it brings its own native migration
-system running on the top of [Alembic](https://alembic.sqlalchemy.org/en/latest/) but making it a
-lot easier to use and more pleasant for you.
+Since **Saffier** owns SQLAlchemy metadata and runs directly on
+[SQLAlchemy 2.x Async](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html), it brings
+its own native migration system running on the top of
+[Alembic](https://alembic.sqlalchemy.org/en/latest/) but making it a lot easier to use and more
+pleasant for you.
 
 Have a look at the [migrations](https://saffier.tarsild.io/migrations.md) for more details.
 

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -1,10 +1,11 @@
 # Connection
 
-Using saffier is extremely simple and easy to do but there are some steps you might want to take
-into consideration like connections and what it can happen if this is not done properly.
+Using Saffier is extremely simple and easy to do, but there are some steps you might want to take
+into consideration around connections and what can happen if this is not done properly.
 
-Saffier is on SQLAlechemy core but is an `async` version of it and therefore what happens if you
-want to use it within your favourite frameworks like [Ravyn](https://ravyn.dymmond.com),
+Saffier runs directly on SQLAlchemy 2.x Async, using `AsyncEngine` and `AsyncConnection`
+under the ORM APIs. What happens if you want to use it within your favourite frameworks like
+[Ravyn](https://ravyn.dymmond.com),
 Starlette or even FastAPI?
 
 Well, Saffier is framework agnostic so it will fit in any framework you want, even in those that
@@ -37,7 +38,7 @@ framework.
 ```
 
 And that is pretty much this. Once the connection is hooked into your application lifecycle you
-won't have error like `AssertationError: DatabaseBackend is not running`.
+will have a live SQLAlchemy async engine available for ORM operations.
 
 You are now free to use the ORM anywhere in your application.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,15 +44,14 @@ programs and relational databases.
 Two of the most well known ORMs are from Django and SQLAlchemy. Both have their own strenghts and
 weaknesses and specific use cases.
 
-This ORM is built on the top of SQLAlchemy core and aims to simplify the way the setup and queries
-are done into a more common and familiar interface.
+This ORM is built directly on SQLAlchemy 2.x Async and aims to simplify setup and queries into a
+more common and familiar interface.
 
 ## Before continuing
 
-Saffier is a Python-native ORM focused on query ergonomics, model expressiveness, and predictable async behavior.
-If your project also needs dedicated data validation or alternate model
-representations, you can integrate Saffier with the engine layer of your
-choice.
+Saffier is a Python-native ORM focused on query ergonomics, model expressiveness, and predictable
+async behavior. If your project also needs dedicated data validation or alternate model
+representations, you can integrate Saffier with the engine layer of your choice.
 
 ## Why this ORM
 
@@ -60,8 +59,8 @@ When investigating for a project different types of ORMs and compared them to ea
 for a lot of use cases, SQLAlchemy always took the win but had an issue, the async support
 (which now there are a few solutions). While doing the research I came across Encode ORM.
 
-The team is the same behind of Databases, Django Rest Framework, Starlette,
-httpx and a lot more tools used by millions.
+The team is the same behind Django Rest Framework, Starlette, httpx and a lot more tools used by
+millions.
 
 There was one issue though, although ORM was doing a great familiar interface with SQLAlchemy and
 providing the async solution needed, it was, by the time of this writting,
@@ -89,7 +88,7 @@ done by the amazing team behind it. For that reason, thank you!
 ## Features
 
 While adopting a familiar interface, it offers some cool and powerful features on the top of
-SQLAlchemy core.
+SQLAlchemy 2.x Async.
 
 ### Key features
 
@@ -124,10 +123,11 @@ And a lot more you can do here.
 
 ## Migrations
 
-Since **Saffier**, like [Encode ORM](https://www.encode.io/orm/), is built on the top of
-[SQLAlchemy core](https://docs.sqlalchemy.org/en/20/core/), it brings its own native migration
-system running on the top of [Alembic](https://alembic.sqlalchemy.org/en/latest/) but making it a
-lot easier to use and more pleasant for you.
+Since **Saffier** owns SQLAlchemy metadata and runs directly on
+[SQLAlchemy 2.x Async](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html), it brings
+its own native migration system running on the top of
+[Alembic](https://alembic.sqlalchemy.org/en/latest/) but making it a lot easier to use and more
+pleasant for you.
 
 Have a look at the [migrations](./migrations/migrations.md) for more details.
 

--- a/docs/migrations/migrations.md
+++ b/docs/migrations/migrations.md
@@ -3,8 +3,8 @@
 You will almost certainly need to be using a database migration tool to make sure you manage
 your incremental database changes properly.
 
-Saffier being on the top of SQLAlchemy core means that we can leverage that within the internal
-migration tool.
+Saffier owns SQLAlchemy metadata directly and runs on SQLAlchemy 2.x Async, which means the
+internal migration tool can inspect the same metadata the ORM uses at runtime.
 
 Saffier provides an internal migration tool that makes your life way easier when it comes to manage
 models and corresponding migrations.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -107,7 +107,7 @@ class User(saffier.Model):
                                 </svg></div>
                             <div>
                                 <h4 class="fw-bold">Friendly</h4>
-                                <p class="text-muted">With familiar interface built on the top of SQLAlchemy core.</p>
+                                <p class="text-muted">With a familiar interface built directly on SQLAlchemy 2.x Async.</p>
                             </div>
                         </div>
                     </div>
@@ -122,7 +122,7 @@ class User(saffier.Model):
                     <h3 class="display-6 fw-bold pb-md-4">Complexity removed to increase&nbsp;<span class="underline">productivity</span></h3>
                 </div>
                 <div class="col-md-6 pt-4">
-                    <p class="text-muted mb-4">Although built on the top of SQLAlchemy core, Saffier with its familair and friendly interface makes it easy and pleasant to work with.</p>
+                    <p class="text-muted mb-4">Although built directly on SQLAlchemy 2.x Async, Saffier with its familair and friendly interface makes it easy and pleasant to work with.</p>
                 </div>
             </div>
             <div class="row gy-4 gy-md-0">

--- a/docs/queries/queries.md
+++ b/docs/queries/queries.md
@@ -150,8 +150,8 @@ users = await User.query.filter(last_login__isnull=True)
 
 #### SQLAlchemy style
 
-Since Saffier uses SQLAlchemy core, it is also possible to do queries in SQLAlchemy style.
-The filter accepts also those.
+Since Saffier builds on SQLAlchemy expressions, it is also possible to do queries in SQLAlchemy
+style. The filter accepts also those.
 
 If you need direct class-attribute access such as `User.id` instead of
 `User.columns.id`, see [SQLAlchemy compatibility mode](./sqlalchemy-compatibility.md).

--- a/docs/references/database.md
+++ b/docs/references/database.md
@@ -1,10 +1,11 @@
 # `Database`
 
-`Database` is Saffier's database connection wrapper.
+`Database` is Saffier's SQLAlchemy Async database runtime.
 
 Most applications interact with it indirectly through a `Registry`, but the
 class is still important because it defines connection lifecycle, transaction
-management, and the SQLAlchemy async engine used by queries and schema helpers.
+management, and the SQLAlchemy `AsyncEngine`, `AsyncConnection`, and
+`async_sessionmaker` used by queries and schema helpers.
 
 ## Typical usage
 
@@ -17,10 +18,10 @@ models = saffier.Registry(database=database)
 
 ## What to know in practice
 
-* prefer `saffier.Database`, not the `databases` package object
+* use `saffier.Database` for registry ownership and ORM execution
 * registry lifecycle usually controls `connect()` and `disconnect()`
-* synchronous reflection paths use the wrapped sync engine derived from the
-  async engine
+* advanced code can inspect the native SQLAlchemy async engine through
+  `database.engine` after connection
 
 ::: saffier.Database
     options:

--- a/docs/references/reflect-model.md
+++ b/docs/references/reflect-model.md
@@ -17,7 +17,7 @@ database rather than generate the table definition from declared fields.
 
 `ReflectModel` is most useful for:
 
-* legacy databases
+* existing production databases
 * reporting or analytics tables maintained elsewhere
 * read-heavy integrations where the table shape is not owned by the Saffier app
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -29,11 +29,11 @@ multi-database applications.
 
 ## Parameters
 
-* **database** - An instance of `saffier.core.db.Database` object.
+* **database** - An instance of the native `saffier.Database` runtime.
 
 !!! Warning
-    Using the `Database` from the `databases` package will raise an assertation error. You must
-    use the `saffier.Database` object instead.
+    Use `saffier.Database` for registry ownership. Plain SQLAlchemy engines, connections, and
+    third-party database objects are not Saffier registry runtimes.
 
 * **schema** - The schema to connect to. This can be very useful for multi-tenancy applications if
 you want to specify a specific schema or simply if you just want to connect to a different schema

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## 2.2.0
+
+Saffier 2.2.0 moves the database runtime fully onto native SQLAlchemy 2.x Async.
+
+The ORM now owns its `AsyncEngine`, `AsyncConnection`, `AsyncSession`, and
+`async_sessionmaker` lifecycle directly. Query execution, transactions, schema
+helpers, database creation and removal, and framework lifespan integration all
+flow through SQLAlchemy's public async APIs.
+
+### Changed
+
+- Replaced the previous database runtime layer with a direct SQLAlchemy 2.x Async implementation.
+- Database URLs now normalize common plain dialects to SQLAlchemy async drivers while preserving the public `DatabaseURL` helper.
+- Transactions now use SQLAlchemy async transaction objects and savepoints directly, including forced rollback scopes.
+- Schema helpers now run through `AsyncConnection.run_sync()` and SQLAlchemy metadata APIs.
+- Documentation now describes Saffier as a first-class SQLAlchemy Async ORM throughout.
+
+### Removed
+
+- Removed the external database runtime dependency from Saffier's runtime requirements.
+- Removed extra database execution indirection from Saffier's runtime path.
+- Removed documentation language that pointed users at the previous database runtime model.
+
 ## 2.1.0
 
 Saffier 2.1.0 expands the ORM into its next layer: engine-pluggable models.
@@ -69,7 +92,7 @@ and... a lot of new features and improvements but also... Faster!
 
 ### Changed
 
-- Add integration with the newly `databasez` 0.8.5+.
+- Updated the database integration used by that release.
 - Internal refactor of the registry.
 
 ### Fixed
@@ -214,7 +237,7 @@ when querying the tenant.
 ### Changed
 
 - `inspectdb` is now handled by an independent isolated called `InspectDB`.
-- Updated internal support for `databasez` 0.7.0 and this fixes the URL parsing errors for complex passwords
+- Updated internal database URL support and fixed URL parsing errors for complex passwords
 caused by the `urlsplit`.
 
 ### Fixed
@@ -403,7 +426,7 @@ PR [#58](https://github.com/tarsil/saffier/pull/58) by [@tarsil](https://github.
 
 ### Changed
 
-- Minor update of the base of databasez package. PR [#56](https://github.com/tarsil/saffier/pull/56) by [@tarsil](https://github.com/tarsil).
+- Minor database integration maintenance update. PR [#56](https://github.com/tarsil/saffier/pull/56) by [@tarsil](https://github.com/tarsil).
 
 ## 0.10.0
 
@@ -497,8 +520,8 @@ to any saffier instance.
 
 ### Changed
 
-- Moved from `databases` to its fork `databasez` and updated internal references.
-- `DatabaseClient` is now being directly used from [Databasez test client](https://databasez.tarsild.io/test-client/).
+- Moved from the original async database package to its then-current fork and updated internal references.
+- `DatabaseClient` was updated to reuse the then-current test database helper.
 
 ### Fixed
 
@@ -541,7 +564,7 @@ to any saffier instance.
     * This brings native generated migrations within Saffier under Alembic's package, allowing
 a seemless integration and cross-compatibility with any framework using Saffier.
 
-- Added new [DatabaseTestClient](./test-client.md) delegating the creating of the `test` database
+- Added new [DatabaseTestClient](./test-client.md) for creating the `test` database
 for each connection string provided.
 
     * No more needed to manually create two separate databases thanks to the client that does the

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,11 @@ flow through SQLAlchemy's public async APIs.
 - Schema helpers now run through `AsyncConnection.run_sync()` and SQLAlchemy metadata APIs.
 - Documentation now describes Saffier as a first-class SQLAlchemy Async ORM throughout.
 
+### Fixed
+
+- Scoped re-entered sync lazy loads so nested event-loop state is restored immediately,
+  preserving Python 3.14 asyncpg compatibility.
+
 ### Removed
 
 - Removed the external database runtime dependency from Saffier's runtime requirements.

--- a/docs/test-client.md
+++ b/docs/test-client.md
@@ -1,11 +1,11 @@
 # Test Client
 
-I'm sure that you already faced the problem with testing your database anmd thinking about a way
-of making sure the tests against models would land in a specific targeted database instead of the
-one used for development, right?
+I'm sure that you already faced the problem with testing your database and thinking about a way
+of making sure model tests land in a specific targeted database instead of the one used for
+development, right?
 
-Well, at least I did and it is annoying the amount of setup required to make it happen and for that
-reason, Saffier provides you already one client that exctly that job for you.
+Well, at least I did and it is annoying the amount of setup required to make it happen. For that
+reason, Saffier provides a SQLAlchemy Async test client that does exactly that job for you.
 
 Before continuing, make sure you have the Saffier test client installed with the needed
 requirements.
@@ -16,8 +16,8 @@ $ pip install saffier[testing]
 
 ## DatabaseTestClient
 
-This is the client you have been waiting for. This object does a lot of magic for you and will
-help you manage those stubborn tests that should land on a `test_` database.
+This is the client you have been waiting for. It manages SQLAlchemy-backed test databases for the
+tests that should land on a `test_` database.
 
 ```python
 from saffier.testclient import DatabaseTestClient
@@ -35,12 +35,12 @@ from saffier.testclient import DatabaseTestClient
     from saffier import DatabaseURL
     ```
 
-* **force_rollback** - This will ensure that all database connections are run within a transaction
-that rollbacks once the database is disconnected.
+* **force_rollback** - This will ensure that database work runs within a SQLAlchemy transaction
+that rolls back once the database is disconnected.
 
     <sup>Default: `False`</sup>
 
-* **lazy_setup** - This sets up the db first up on connect not in init.
+* **lazy_setup** - This sets up the test database on first connect instead of during initialization.
 
     <sup>Default: `True`</sup>
 
@@ -67,8 +67,9 @@ This is used for the tests.
 
 ### How to use it
 
-This is the easiest part because is already very familiar with the `Database` used by Saffier. In
-fact, this is an extension of that same object with a lot of testing flavours.
+This is the easiest part because it is already familiar with the `Database` used by Saffier. In
+fact, this is an extension of that same SQLAlchemy Async runtime with test database setup and
+teardown behavior.
 
 Let us assume you have a database url like this following:
 
@@ -96,5 +97,5 @@ database operation you want will be on a `test_` database.
 
 But you can see a `drop_database=True`, so what is that?
 
-Well `drop_database=True` means that by the end of the tests finish running, drops the database
-into oblivion.
+Well `drop_database=True` means that by the time the tests finish running, Saffier drops the test
+database.

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,7 +1,7 @@
 # Transactions
 
-Saffier using `databases` package allows also the use of transacations in a very familiar way for
-a lot of the users.
+Saffier uses SQLAlchemy 2.x Async transaction management directly, while keeping a familiar
+transaction API for application code.
 
 You can see a transaction as atomic, which means, when you need to save everything or fail all.
 
@@ -19,7 +19,7 @@ Let us also assume we want to create a `user` and a `profile` for that user in a
 
 !!! danger
     If you are trying to setup your connection within your application and have faced some errors
-    such as `AssertationError: DatabaseBackend is not running`, please see the [connection](./connection.md)
+    related to a disconnected SQLAlchemy async engine, please see the [connection](./connection.md)
     section for more details and how to make it properly.
 
 ```python
@@ -55,9 +55,9 @@ or an operation, you will need to make some transactions that need atomocity.
 
 ## Important notes
 
-Saffier although running on the top of [Databases](https://www.encode.io/databases/) it varies in
-many aspects and limits some of the unecessary `free-style` usage to make sure it keeps its
-consistance.
+Saffier transactions run directly on SQLAlchemy's async transaction objects.
+Nested transaction blocks use SQLAlchemy savepoints, and `force_rollback=True` keeps test writes
+inside a rollback-only SQLAlchemy transaction for isolation.
 
-If you are interested in knowing more about the low-level APIs of databases,
-[check out](https://www.encode.io/databases/) their [documentation](https://www.encode.io/databases/).
+If you need lower-level access, use the native SQLAlchemy async APIs exposed by
+`database.engine`, `database.connection()`, or `database.session()`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ plugins:
               - griffe_typingdoc
             show_root_heading: true
             show_if_no_docstring: true
-            preload_modules: [databasez]
+            preload_modules: [sqlalchemy]
             inherited_members: true
             members_order: source
             separate_signature: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "anyio>=4.9.0,<5",
     "sayer>=0.7.0,<0.8.0",
     "click>=8.3.1,<9.0.0",
-    "databasez>=0.9.2",
+    "sqlalchemy[asyncio]>=2.0.0,<3.0.0",
     "monkay>=0.5.0",
     "orjson >=3.8.5,<4.0.0",
     "rich>=14.0.0,<16.0.0",
@@ -87,7 +87,7 @@ test = [
     "pymysql>=1.0.2,<2.0.0",
     "types-orjson==3.6.2",
     "ruff>=0.14.2,<1.0.0",
-    "ty>=0.0.1",
+    "ty>=0.0.58",
     "pydantic",
     "msgspec"
 ]
@@ -96,7 +96,7 @@ dev = [
     "autoflake >=1.4.0",
     "uvicorn[standard] >=0.19.0",
     "pre-commit>=4.0.0,<5.0.0",
-    "ty>=0.0.1",
+    "ty>=0.0.58",
 ]
 
 doc = [
@@ -112,9 +112,9 @@ doc = [
 ]
 
 testing = ["sqlalchemy_utils>=0.40.0"]
-postgres = ["databasez[postgresql]"]
-mysql = ["databasez[mysql]"]
-sqlite = ["databasez[sqlite]"]
+postgres = ["asyncpg>=0.27.0,<1"]
+mysql = ["asyncmy>=0.2.7,<0.3.0"]
+sqlite = ["aiosqlite>=0.19.0,<1"]
 
 ptpython = ["ptpython>=3.0.23,<4.0.0"]
 ipython = ["ipython>=8.10.0,<9.0.0"]
@@ -127,7 +127,9 @@ admin = [
 ]
 
 all = [
-    "databasez[postgresql,mysql,sqlite]",
+    "asyncpg>=0.27.0,<1",
+    "asyncmy>=0.2.7,<0.3.0",
+    "aiosqlite>=0.19.0,<1",
     "orjson>=3.8.5,<4.0.0",
     "ptpython>=3.0.23,<4.0.0",
     "ipython>=8.10.0,<9.0.0",

--- a/saffier/__init__.py
+++ b/saffier/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 import importlib
 import sys

--- a/saffier/cli/operations/shell/base.py
+++ b/saffier/cli/operations/shell/base.py
@@ -1,9 +1,10 @@
+import asyncio
+import contextlib
 import select
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from typing import Annotated, Any
 
-import nest_asyncio
 from sayer import Option, command, error
 
 from saffier import Registry
@@ -11,6 +12,7 @@ from saffier.cli.operations.shell.enums import ShellOption
 from saffier.cli.state import get_migration_app, get_migration_registry
 from saffier.core.events import AyncLifespanContextManager
 from saffier.core.sync import execsync
+from saffier.core.utils.sync import _temporary_loop_reentry
 
 
 @command
@@ -63,15 +65,14 @@ async def run_shell(app: Any, lifespan: Any, registry: Registry, kernel: str) ->
     sees the same initialized state as the running application.
     """
     if lifespan is None:
-        nest_asyncio.apply()
         if kernel == ShellOption.IPYTHON:
             from saffier.cli.operations.shell.ipython import get_ipython
 
-            get_ipython(app=app, registry=registry)()
+            _run_shell_with_loop_reentry(get_ipython(app=app, registry=registry))
         else:
             from saffier.cli.operations.shell.ptpython import get_ptpython
 
-            get_ptpython(app=app, registry=registry)()
+            _run_shell_with_loop_reentry(get_ptpython(app=app, registry=registry))
         return
 
     async with lifespan(app):
@@ -79,14 +80,41 @@ async def run_shell(app: Any, lifespan: Any, registry: Registry, kernel: str) ->
             from saffier.cli.operations.shell.ipython import get_ipython
 
             ipython_shell = get_ipython(app=app, registry=registry)
-            nest_asyncio.apply()
-            ipython_shell()
+            _run_shell_with_loop_reentry(ipython_shell)
         else:
             from saffier.cli.operations.shell.ptpython import get_ptpython
 
             ptpython = get_ptpython(app=app, registry=registry)
-            nest_asyncio.apply()
-            ptpython()
+            _run_shell_with_loop_reentry(ptpython)
+
+
+@contextlib.contextmanager
+def _shell_loop_reentry() -> Iterator[None]:
+    """Temporarily permit nested event-loop use while a shell is active.
+
+    Embedded IPython and ptpython sessions are synchronous callables launched
+    from Saffier's async lifespan runner. While the shell owns the thread, users
+    may still execute async ORM commands that need the already-initialized
+    SQLAlchemy event loop. This context uses the same scoped re-entry helper as
+    ``saffier.run_sync()`` so shell support does not leave global asyncio state
+    patched after the interactive session exits.
+
+    Yields:
+        None: Control while the active event loop can be re-entered.
+    """
+    with _temporary_loop_reentry(asyncio.get_running_loop()):
+        yield
+
+
+def _run_shell_with_loop_reentry(shell_runner: Callable[[], None]) -> None:
+    """Execute one interactive shell callable inside a scoped loop patch.
+
+    Args:
+        shell_runner: Callable returned by the selected shell backend. It owns
+            the terminal session until the user exits IPython or ptpython.
+    """
+    with _shell_loop_reentry():
+        shell_runner()
 
 
 def handle_lifespan_events(

--- a/saffier/core/connection/database.py
+++ b/saffier/core/connection/database.py
@@ -1,3 +1,1787 @@
-from databasez import Database, DatabaseURL
+"""Native SQLAlchemy Async database runtime for Saffier.
 
-__all__ = ["Database", "DatabaseURL"]
+This module is the runtime boundary between Saffier's ORM layer and
+SQLAlchemy 2.x. It owns URL handling, async engine/session creation,
+connection-scoped execution helpers, transaction scopes, and the test database
+client without delegating database work outside SQLAlchemy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+import weakref
+from collections.abc import AsyncGenerator, Callable, Iterator, Sequence
+from contextvars import ContextVar, Token
+from functools import cached_property, wraps
+from typing import Any, TypeVar, cast
+from urllib.parse import SplitResult, parse_qs, quote, unquote, urlencode, urlsplit
+
+import orjson
+import sqlalchemy
+from sqlalchemy.engine.url import URL, make_url
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
+    AsyncEngine,
+    AsyncSession,
+    AsyncTransaction,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+try:
+    from monkay.asgi import ASGIApp, LifespanHook
+except Exception:  # pragma: no cover - optional integration import guard
+    ASGIApp = Any  # type: ignore[misc,assignment]
+    LifespanHook = None  # type: ignore[assignment]
+
+
+_CallableType = TypeVar("_CallableType", bound=Callable[..., Any])
+
+
+def _coerce_statement(query: sqlalchemy.ClauseElement | str) -> sqlalchemy.ClauseElement:
+    """Normalize public execution input into a SQLAlchemy statement.
+
+    Saffier's low-level helpers accept both SQLAlchemy clause elements and raw
+    SQL strings. SQLAlchemy's async execution path expects a clause element, so
+    strings are wrapped with ``sqlalchemy.text()`` while already-built
+    statements pass through unchanged.
+    """
+    return sqlalchemy.text(query) if isinstance(query, str) else query
+
+
+def _async_url(url: DatabaseURL) -> URL:
+    """Build the SQLAlchemy URL used to create the async engine.
+
+    Public Saffier URLs may omit the async driver for common dialects because
+    older examples used plain ``postgresql://`` or ``sqlite://`` schemes. This
+    helper keeps those URLs accepted while selecting SQLAlchemy's async drivers
+    before ``create_async_engine()`` is called.
+    """
+    sqla_url = url.sqla_url
+    if sqla_url.drivername in {"sqlite", "postgres", "postgresql", "mysql"}:
+        drivers = {
+            "sqlite": "sqlite+aiosqlite",
+            "postgres": "postgresql+asyncpg",
+            "postgresql": "postgresql+asyncpg",
+            "mysql": "mysql+asyncmy",
+        }
+        return sqla_url.set(drivername=drivers[sqla_url.drivername])
+    return sqla_url
+
+
+def _json_serializer(value: Any) -> str:
+    """Serialize Python JSON values for SQLAlchemy engine options.
+
+    SQLAlchemy dialects such as asyncpg can receive serializer hooks at engine
+    creation time. Saffier uses ``orjson`` here so JSON field behavior stays
+    consistent with the rest of the ORM while the engine remains native
+    SQLAlchemy.
+    """
+    return orjson.dumps(value).decode("utf8")
+
+
+def _json_deserializer(value: str | bytes | bytearray) -> Any:
+    """Deserialize JSON payloads returned through SQLAlchemy dialect hooks.
+
+    Driver implementations may hand back text or bytes. Routing through
+    ``orjson.loads`` keeps Saffier's JSON handling centralized without adding a
+    database runtime layer above SQLAlchemy.
+    """
+    return orjson.loads(value)
+
+
+def _batch_rows(rows: Sequence[Any], batch_size: int) -> Iterator[Sequence[Any]]:
+    """Split an in-memory result sequence into stable batch slices.
+
+    ``Database.batched_iterate()`` keeps a compatibility API that yields grouped
+    rows. This helper performs that grouping with basic slicing so Saffier does
+    not need newer ``itertools`` helpers unavailable on older supported Python
+    versions.
+    """
+    for index in range(0, len(rows), batch_size):
+        yield rows[index : index + batch_size]
+
+
+ACTIVE_FORCE_ROLLBACKS: ContextVar[weakref.WeakKeyDictionary[Any, bool] | None] = ContextVar(
+    "ACTIVE_FORCE_ROLLBACKS",
+    default=None,
+)
+
+
+class ForceRollback:
+    """Context-local boolean flag controlling forced rollback behavior.
+
+    The flag has a default value, but tests and schema helpers can temporarily
+    override it in the current context with ``database.force_rollback(True)`` or
+    ``database.force_rollback(False)``.
+    """
+
+    default: bool
+
+    def __init__(self, default: bool) -> None:
+        """Create a rollback flag with its process-level default.
+
+        The flag is later read through context-local overrides, so the default
+        represents the behavior for code that has not explicitly entered a
+        ``database.force_rollback(...)`` block.
+        """
+        self.default = default
+
+    def set(self, value: bool | None = None) -> None:
+        """Set or clear this flag in the current context.
+
+        A copied weak-key dictionary is written back into the context variable
+        so nested tests can isolate their override without mutating rollback
+        state that belongs to a parent task or another database instance.
+        """
+        force_rollbacks = ACTIVE_FORCE_ROLLBACKS.get()
+        if force_rollbacks is None:
+            if value is None:
+                return
+            force_rollbacks = weakref.WeakKeyDictionary()
+        else:
+            force_rollbacks = force_rollbacks.copy()
+        if value is None:
+            force_rollbacks.pop(self, None)
+        else:
+            force_rollbacks[self] = value
+        ACTIVE_FORCE_ROLLBACKS.set(force_rollbacks)
+
+    def __bool__(self) -> bool:
+        """Resolve the rollback state visible to the current task.
+
+        Context-specific values win over the constructor default. This lets
+        tests temporarily enable or disable forced rollback while unrelated
+        execution paths keep the configured default.
+        """
+        force_rollbacks = ACTIVE_FORCE_ROLLBACKS.get()
+        if force_rollbacks is None:
+            return self.default
+        return force_rollbacks.get(self, self.default)
+
+    @contextlib.contextmanager
+    def __call__(self, force_rollback: bool = True) -> Iterator[None]:
+        """Temporarily override rollback mode inside a synchronous block.
+
+        The previous effective value is restored on exit, including when the
+        block raises. This mirrors the public behavior Saffier exposes for
+        scoped test isolation flags.
+        """
+        initial = bool(self)
+        self.set(force_rollback)
+        try:
+            yield
+        finally:
+            self.set(initial)
+
+
+class ForceRollbackDescriptor:
+    """Expose ``database.force_rollback`` as both a value and scoped mutator.
+
+    The descriptor keeps the public attribute ergonomic while the actual state
+    lives in ``ForceRollback``. Assignment changes the current context, access
+    returns the context-aware flag object, and deletion clears the override.
+    """
+
+    def __get__(self, obj: Database, objtype: type[Database]) -> ForceRollback:
+        """Return the context-aware rollback flag for a database instance.
+
+        Callers can coerce the returned object to ``bool`` or call it as a
+        context manager. The descriptor deliberately exposes the same object so
+        both interaction styles share one source of rollback state.
+        """
+        return obj._force_rollback
+
+    def __set__(self, obj: Database, value: bool | None) -> None:
+        """Set or reset the current context's rollback override.
+
+        Attribute assignment remains supported for compatibility, but only
+        booleans and ``None`` are valid because the value feeds transaction
+        control directly.
+        """
+        assert value is None or isinstance(value, bool), f"Invalid type: {value!r}."
+        obj._force_rollback.set(value)
+
+    def __delete__(self, obj: Database) -> None:
+        """Clear the current context's rollback override.
+
+        Deleting the attribute does not remove the descriptor; it simply returns
+        this task to the database's configured default rollback behavior.
+        """
+        obj._force_rollback.set(None)
+
+
+class DatabaseURL:
+    """Small URL helper backed by SQLAlchemy's ``URL`` parser.
+
+    Saffier keeps this public helper for URL inspection, safe password masking,
+    and test database URL rewriting, while relying on SQLAlchemy for canonical
+    parsing and dialect resolution.
+    """
+
+    def __init__(self, url: str | DatabaseURL | URL | None = None) -> None:
+        """Create a normalized public URL wrapper.
+
+        ``DatabaseURL`` accepts strings, SQLAlchemy ``URL`` objects, and other
+        ``DatabaseURL`` instances so callers can move between Saffier and
+        SQLAlchemy APIs without losing password handling or test URL rewriting.
+        """
+        if isinstance(url, DatabaseURL):
+            self._url = url._url
+        elif isinstance(url, URL):
+            self._url = url.render_as_string(hide_password=False)
+        elif isinstance(url, str):
+            self._url = url
+        elif url is None:
+            self._url = "invalid://localhost"
+        else:
+            raise TypeError(
+                f"Invalid type for DatabaseURL. Expected str or DatabaseURL, got {type(url)}"
+            )
+
+    @cached_property
+    def sqla_url(self) -> URL:
+        """Return the parsed SQLAlchemy ``URL`` representation.
+
+        Parsing is delegated to SQLAlchemy so dialect names, drivers, hosts, and
+        query options follow SQLAlchemy 2.x rules. The value is cached because
+        URL inspection happens often during registry and test-client setup.
+        """
+        return make_url(self._url)
+
+    @cached_property
+    def components(self) -> SplitResult:
+        """Return split URL components with SQLite paths preserved.
+
+        ``urllib.parse`` and SQLAlchemy render SQLite paths with subtly
+        different slash counts. The normalization here keeps Saffier's historic
+        ``DatabaseURL`` string behavior while still relying on SQLAlchemy for
+        the initial parse.
+        """
+        components = urlsplit(self.sqla_url.render_as_string(hide_password=False))
+        if components.path.startswith("///"):
+            components = components._replace(path=f"//{components.path.lstrip('/')}")
+        return components
+
+    @classmethod
+    def get_url(cls, splitted: SplitResult) -> str:
+        """Reassemble a ``SplitResult`` into Saffier's URL string form.
+
+        ``DatabaseURL.replace()`` works by modifying split components. This
+        helper centralizes the final rendering step so path, query, and fragment
+        handling stays identical across replacements and ``str(database_url)``.
+        """
+        url = f"{splitted.scheme}://{splitted.netloc or ''}{splitted.path}"
+        if splitted.query:
+            url = f"{url}?{splitted.query}"
+        if splitted.fragment:
+            url = f"{url}#{splitted.fragment}"
+        return url
+
+    @property
+    def scheme(self) -> str:
+        """Return the complete URL scheme.
+
+        The scheme may include both a SQL dialect and driver, for example
+        ``postgresql+asyncpg``. Saffier exposes it because migrations, tests,
+        and diagnostics need to preserve that exact public value.
+        """
+        return self.components.scheme
+
+    @property
+    def dialect(self) -> str:
+        """Return the SQLAlchemy dialect name from the URL scheme.
+
+        Driver names are intentionally removed here so callers can branch on the
+        database family, such as ``postgresql`` or ``sqlite``, without caring
+        which async DBAPI driver was selected.
+        """
+        return self.scheme.split("+")[0]
+
+    @property
+    def driver(self) -> str | None:
+        """Return the explicit SQLAlchemy driver name, when configured.
+
+        URLs such as ``postgresql+asyncpg://`` expose ``asyncpg`` here, while
+        plain dialect URLs return ``None``. Engine creation later fills in async
+        defaults for common plain schemes.
+        """
+        scheme_parts = self.scheme.split("+", 1)
+        if len(scheme_parts) == 1:
+            return None
+        return scheme_parts[1]
+
+    @property
+    def userinfo(self) -> bytes | None:
+        """Return the percent-encoded user information segment.
+
+        This mirrors the historical ``DatabaseURL`` API used by callers that
+        need the raw authority credentials. Usernames and passwords are encoded
+        separately so special characters are preserved safely.
+        """
+        if self.components.username:
+            info = quote(self.components.username, safe="+")
+            if self.password:
+                info += ":" + quote(self.password, safe="+")
+            return info.encode("utf-8")
+        return None
+
+    @property
+    def username(self) -> str | None:
+        """Return the decoded username component.
+
+        SQLAlchemy keeps the parsed username available, and Saffier decodes it
+        here so callers receive the same value they originally intended rather
+        than percent-escaped text.
+        """
+        if self.components.username is None:
+            return None
+        return unquote(self.components.username)
+
+    @property
+    def password(self) -> str | None:
+        """Return the decoded password component.
+
+        The value is available for connection construction but is never used by
+        ``repr()`` or ``obscure_password``. Those public renderers hide secrets
+        while this property preserves explicit inspection behavior.
+        """
+        if self.components.password is None:
+            return None
+        return unquote(self.components.password)
+
+    @property
+    def hostname(self) -> str | None:
+        """Return the network host or socket-style host option.
+
+        Some database URLs place a Unix socket path in the query string instead
+        of the hostname slot. This property keeps those connection strings
+        usable by checking both locations.
+        """
+        host = self.components.hostname or self.options.get("host")
+        if isinstance(host, list):
+            return host[0] if host else None
+        return host
+
+    @property
+    def port(self) -> int | None:
+        """Return the parsed TCP port.
+
+        SQLAlchemy and ``urllib`` validate the port during parsing, so callers
+        receive either an integer port or ``None`` when the URL intentionally
+        omits one.
+        """
+        return self.components.port
+
+    @property
+    def netloc(self) -> str | None:
+        """Return the rendered network-location component.
+
+        The value includes credentials, host, and port exactly as represented in
+        the split URL. It is mostly used when reconstructing modified URLs.
+        """
+        return self.components.netloc
+
+    @property
+    def database(self) -> str:
+        """Return the decoded database name from the URL path.
+
+        Saffier treats the leading slash as URL structure rather than part of
+        the database name. The remaining path is decoded so test database
+        prefixes and DDL helpers operate on the logical database identifier.
+        """
+        path = self.components.path
+        if path.startswith("/"):
+            path = path[1:]
+        return unquote(path)
+
+    @cached_property
+    def options(self) -> dict[str, str | list[str]]:
+        """Return URL query parameters in Saffier's public option format.
+
+        Single-value parameters are simplified to strings, while repeated
+        parameters remain lists. ``Database`` later moves known engine options
+        out of this mapping before passing the URL to SQLAlchemy.
+        """
+        result: dict[str, str | list[str]] = {}
+        for key, value in parse_qs(self.components.query).items():
+            result[key] = value[0] if len(value) == 1 else value
+        return result
+
+    def replace(self, **kwargs: Any) -> DatabaseURL:
+        """Return a new URL with selected logical components replaced.
+
+        The method accepts Saffier-friendly names such as ``database``,
+        ``dialect``, ``driver``, ``username``, and ``options``. It rewrites the
+        underlying split URL while preserving proper percent-encoding and
+        leaving the original ``DatabaseURL`` immutable.
+        """
+        if (
+            "username" in kwargs
+            or "user" in kwargs
+            or "password" in kwargs
+            or "hostname" in kwargs
+            or "host" in kwargs
+            or "port" in kwargs
+        ):
+            hostname = kwargs.pop("hostname", kwargs.pop("host", self.hostname))
+            port = kwargs.pop("port", self.port)
+            username = kwargs.pop("username", kwargs.pop("user", self.components.username))
+            password = kwargs.pop("password", self.components.password)
+
+            netloc = hostname or ""
+            if port is not None:
+                netloc += f":{port}"
+            if username is not None:
+                userpass = quote(username, safe="+")
+                if password is not None:
+                    userpass += f":{quote(password, safe='+')}"
+                netloc = f"{userpass}@{netloc}"
+
+            kwargs["netloc"] = netloc
+
+        if "database" in kwargs:
+            database = kwargs.pop("database")
+            kwargs["path"] = "" if database is None else f"/{database}"
+
+        if "dialect" in kwargs or "driver" in kwargs:
+            dialect = kwargs.pop("dialect", self.dialect)
+            driver = kwargs.pop("driver", self.driver)
+            kwargs["scheme"] = f"{dialect}+{driver}" if driver else dialect
+
+        if not kwargs.get("netloc", self.netloc):
+            kwargs["netloc"] = ""
+        if "options" in kwargs:
+            kwargs["query"] = urlencode(kwargs.pop("options"), doseq=True)
+
+        components = self.components._replace(**kwargs)
+        return self.__class__(self.get_url(components))
+
+    @cached_property
+    def obscure_password(self) -> str:
+        """Return a string representation suitable for logs and repr output.
+
+        Password masking is delegated to SQLAlchemy's URL renderer so the
+        output follows SQLAlchemy's escaping rules while still protecting
+        credentials from accidental disclosure.
+        """
+        return self.sqla_url.render_as_string(hide_password=True)
+
+    def __str__(self) -> str:
+        """Return the full public URL string.
+
+        The string form intentionally preserves the clear password because it is
+        used for actual connection setup. Use ``obscure_password`` or ``repr``
+        when a safe diagnostic representation is needed.
+        """
+        return self.get_url(self.components)
+
+    def __repr__(self) -> str:
+        """Return a developer-facing representation with credentials hidden.
+
+        The representation names the wrapper class and masks the password so
+        debugging output can identify the target database without leaking
+        secrets.
+        """
+        return f"{self.__class__.__name__}({self.obscure_password!r})"
+
+    def __eq__(self, other: Any) -> bool:
+        """Compare URL wrappers using their rendered public URL value.
+
+        String values are first converted to ``DatabaseURL`` so equality works
+        naturally in tests and public API code that compares raw configuration
+        strings against parsed URL objects.
+        """
+        if isinstance(other, str):
+            other = DatabaseURL(other)
+        return str(self) == str(other)
+
+
+_ACTIVE_CONNECTIONS: ContextVar[dict[int, tuple[AsyncConnection, ...]] | None] = ContextVar(
+    "_ACTIVE_CONNECTIONS",
+    default=None,
+)
+_LOOP_BOUND_DATABASES: ContextVar[tuple[int, ...]] = ContextVar(
+    "_LOOP_BOUND_DATABASES",
+    default=(),
+)
+_LOOP_BOUND_TOKEN_STACKS: ContextVar[dict[int, tuple[Token[tuple[int, ...]], ...]] | None] = (
+    ContextVar(
+        "_LOOP_BOUND_TOKEN_STACKS",
+        default=None,
+    )
+)
+
+
+def _active_connections() -> dict[int, tuple[AsyncConnection, ...]]:
+    """Return the current context's transaction connection stacks.
+
+    The context variable uses ``None`` as its default to avoid sharing a mutable
+    dictionary between tasks. Callers receive an empty dictionary when no
+    transaction has bound a SQLAlchemy connection in this context.
+    """
+    return _ACTIVE_CONNECTIONS.get() or {}
+
+
+def _loop_bound_token_stacks() -> dict[int, tuple[Token[tuple[int, ...]], ...]]:
+    """Return loop-bound marker tokens stored for the current context.
+
+    Each task that enters a force-rollback database context owns its own token
+    stack. Returning an empty dictionary for the unset state keeps the storage
+    immutable-by-default and avoids cross-task token resets.
+    """
+    return _LOOP_BOUND_TOKEN_STACKS.get() or {}
+
+
+def should_reenter_sync_bridge() -> bool:
+    """Return whether sync code must stay on the current event loop.
+
+    SQLAlchemy ``AsyncConnection`` objects and their asyncpg driver connections
+    are loop-bound. The sync bridge uses this signal to avoid moving ORM lazy
+    loads onto a helper loop while a transaction or force-rollback connection is
+    active.
+    """
+
+    return bool(_active_connections() or _LOOP_BOUND_DATABASES.get())
+
+
+class Transaction:
+    """SQLAlchemy transaction context used by Saffier query and model APIs.
+
+    A transaction binds Saffier execution helpers to one ``AsyncConnection`` in
+    a context variable. Nested Saffier transactions use SQLAlchemy savepoints via
+    ``begin_nested()``, and ``force_rollback`` always rolls back on exit.
+    """
+
+    def __init__(self, database: Database, force_rollback: bool = False, **kwargs: Any) -> None:
+        """Prepare a transaction for a specific Saffier database.
+
+        The transaction does not acquire a connection until ``start()`` or
+        ``async with`` is used. This keeps construction cheap and lets decorator
+        usage create a fresh SQLAlchemy transaction for each function call.
+        """
+        self.database = database
+        self._force_rollback = force_rollback
+        self._extra_options = kwargs
+        self._connection: AsyncConnection | None = None
+        self._transaction: AsyncTransaction | None = None
+        self._token: Token[dict[int, tuple[AsyncConnection, ...]] | None] | None = None
+        self._owns_connection = False
+        self._is_active = False
+
+    async def __aenter__(self) -> Transaction:
+        """Start the SQLAlchemy transaction for ``async with`` usage.
+
+        Entering the context binds the selected ``AsyncConnection`` to Saffier's
+        execution context so all ORM operations inside the block share the same
+        SQLAlchemy transaction or savepoint.
+        """
+        await self.start(cleanup_on_error=False)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: Any = None,
+    ) -> None:
+        """Finish the transaction according to the context outcome.
+
+        Exceptions and explicit ``force_rollback`` requests roll the underlying
+        SQLAlchemy transaction back. A clean exit commits, matching the public
+        Saffier transaction API while using SQLAlchemy's transaction object.
+        """
+        del exc_value, traceback
+        if not self._is_active:
+            return
+        if exc_type is not None or self._force_rollback:
+            await self.rollback()
+        else:
+            await self.commit()
+
+    def __await__(self) -> Any:
+        """Support manual transaction startup with ``await``.
+
+        Some existing Saffier code awaits ``database.transaction()`` and then
+        calls ``commit()`` or ``rollback()`` itself. Returning ``start()`` here
+        preserves that public flow while still using native SQLAlchemy objects.
+        """
+        return self.start().__await__()
+
+    def __call__(self, func: _CallableType) -> _CallableType:
+        """Wrap an async callable in a fresh transaction.
+
+        Decorator usage must not reuse the same ``Transaction`` instance across
+        calls, because each invocation needs its own SQLAlchemy transaction
+        lifecycle and context-variable binding.
+        """
+
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """Execute the decorated coroutine inside its own transaction.
+
+            A new transaction object is created for each call so concurrent
+            invocations do not share SQLAlchemy transaction state or
+            context-variable bindings.
+            """
+            async with self.__class__(
+                self.database,
+                force_rollback=self._force_rollback,
+                **self._extra_options,
+            ):
+                return await func(*args, **kwargs)
+
+        return cast("_CallableType", wrapper)
+
+    async def start(self, cleanup_on_error: bool = True) -> Transaction:
+        """Acquire a connection, begin a transaction, and bind it to the task.
+
+        The method reuses an existing context-bound connection for nested
+        transactions and uses ``begin_nested()`` when SQLAlchemy reports an
+        active transaction. Otherwise it opens a new connection and begins a
+        normal transaction directly through SQLAlchemy.
+        """
+        if self._is_active:
+            raise RuntimeError("Transaction is already active")
+        await self.database._ensure_connected()
+        connection = await self.database._transaction_connection()
+        self._connection = connection
+        self._owns_connection = self.database._current_connection() is None and (
+            not bool(self.database.force_rollback)
+            or connection is not self.database._global_connection
+        )
+        try:
+            await self._apply_transaction_options(connection)
+            self._transaction = (
+                await connection.begin_nested()
+                if connection.in_transaction()
+                else await connection.begin()
+            )
+            self._token = self.database._push_connection(connection)
+            self._is_active = True
+            return self
+        except BaseException:
+            if cleanup_on_error and self._owns_connection:
+                await connection.close()
+            self._connection = None
+            self._owns_connection = False
+            raise
+
+    async def _apply_transaction_options(self, connection: AsyncConnection) -> None:
+        """Apply SQLAlchemy execution options before transaction start.
+
+        Isolation level changes must happen before ``begin()`` on SQLAlchemy
+        connections. Nested transactions skip this step because the outer
+        transaction already owns the connection-level options.
+        """
+        if connection.in_transaction():
+            return
+        options = dict(self._extra_options)
+        if "isolation_level" not in options:
+            options["isolation_level"] = "SERIALIZABLE"
+        if options:
+            await connection.execution_options(**options)
+
+    async def _finish(self, action: str) -> None:
+        """Finalize the active SQLAlchemy transaction and clean context state.
+
+        The context-variable binding is reset even if commit or rollback raises.
+        Connections opened by this transaction are closed, while connections
+        inherited from an outer transaction or force-rollback context remain
+        owned by that outer scope.
+        """
+        if not self._is_active or self._transaction is None:
+            raise RuntimeError("Transaction is not active")
+        transaction = self._transaction
+        self._transaction = None
+        self._is_active = False
+        try:
+            if action == "commit":
+                await transaction.commit()
+            else:
+                await transaction.rollback()
+        finally:
+            if self._token is not None:
+                _ACTIVE_CONNECTIONS.reset(self._token)
+                self._token = None
+            connection, self._connection = self._connection, None
+            if self._owns_connection and connection is not None:
+                await connection.close()
+            self._owns_connection = False
+
+    async def commit(self) -> None:
+        """Commit the active SQLAlchemy transaction.
+
+        Manual transaction users call this after ``await database.transaction()``.
+        It delegates to the same cleanup path used by ``async with`` so context
+        bindings and owned connections are released consistently.
+        """
+        await self._finish("commit")
+
+    async def rollback(self) -> None:
+        """Roll back the active SQLAlchemy transaction.
+
+        This is used by explicit manual rollback, exception-driven context exit,
+        and forced rollback scopes. Cleanup mirrors ``commit()`` so the database
+        runtime does not retain stale context-bound connections.
+        """
+        await self._finish("rollback")
+
+
+class Database:
+    """Saffier database runtime backed directly by SQLAlchemy Async.
+
+    The class owns an ``AsyncEngine``, an ``async_sessionmaker``, and execution
+    helpers used by Saffier's ORM internals. Every database operation delegates
+    to SQLAlchemy's public async engine, connection, transaction, and result
+    APIs.
+    """
+
+    force_rollback = ForceRollbackDescriptor()
+    default_batch_size: int = 100
+
+    def __init__(
+        self,
+        url: str | DatabaseURL | URL | Database | None = None,
+        *,
+        force_rollback: bool | None = None,
+        config: dict[str, Any] | None = None,
+        full_isolation: bool | None = None,
+        poll_interval: float | None = None,
+        **options: Any,
+    ) -> None:
+        """Configure URL, engine options, and rollback behavior for the runtime.
+
+        Engine creation is intentionally delayed until ``connect()`` so registry
+        setup remains lightweight. Copy construction preserves the source
+        database's URL and options while still creating independent SQLAlchemy
+        engine and transaction state.
+        """
+        assert config is None or url is None, "Use either 'url' or 'config', not both."
+        if isinstance(url, Database):
+            assert not options, "Cannot specify options when copying a Database object."
+            self.url = url.url
+            self.options = dict(url.options)
+            if force_rollback is None:
+                force_rollback = bool(url.force_rollback)
+            if full_isolation is None:
+                full_isolation = url._full_isolation
+            if poll_interval is None:
+                poll_interval = url.poll_interval
+        else:
+            database_url = DatabaseURL(url)
+            if config and "connection" in config:
+                connection_config = config["connection"]
+                if "credentials" in connection_config:
+                    database_url = database_url.replace(**connection_config["credentials"])
+            self.url, self.options = self._extract_options(database_url, **options)
+            if force_rollback is None:
+                force_rollback = False
+            if full_isolation is None:
+                full_isolation = False
+            if poll_interval is None:
+                poll_interval = 0.01
+
+        self.poll_interval = poll_interval
+        self._full_isolation = full_isolation
+        self._force_rollback = ForceRollback(force_rollback)
+        self._engine: AsyncEngine | None = None
+        self._sessionmaker: async_sessionmaker[AsyncSession] | None = None
+        self._global_connection: AsyncConnection | None = None
+        self._global_transaction: AsyncTransaction | None = None
+        self.is_connected = False
+        self.ref_counter = 0
+        self.ref_lock = asyncio.Lock()
+
+    def __copy__(self) -> Database:
+        """Return a new runtime object with the same configuration.
+
+        The copy shares URL and option values but not live SQLAlchemy engines,
+        connections, transactions, or context state. This is used by registry
+        preparation paths that need an isolated runtime handle.
+        """
+        return self.__class__(self)
+
+    @staticmethod
+    def _extract_options(
+        database_url: DatabaseURL,
+        **options: Any,
+    ) -> tuple[DatabaseURL, dict[str, Any]]:
+        """Separate SQLAlchemy engine options from URL query parameters.
+
+        Saffier accepts selected engine options in the URL for compatibility
+        with existing configuration. Known values are removed from the URL and
+        passed directly to ``create_async_engine()`` so SQLAlchemy owns pool,
+        isolation, echo, and JSON behavior.
+        """
+        options.setdefault("pool_reset_on_return", None)
+        options.setdefault("json_serializer", _json_serializer)
+        options.setdefault("json_deserializer", _json_deserializer)
+        query_options = dict(database_url.options)
+        for param in ("ssl", "echo", "echo_pool"):
+            if param in query_options:
+                assert param not in options
+                value = cast("str", query_options.pop(param))
+                options[param] = value.lower() in {"true", ""}
+        if "isolation_level" in query_options:
+            assert "isolation_level" not in options
+            options["isolation_level"] = cast("str", query_options.pop("isolation_level"))
+        for param in ("pool_size", "max_overflow"):
+            if param in query_options:
+                assert param not in options
+                options[param] = int(cast("str", query_options.pop(param)))
+        if "pool_recycle" in query_options:
+            assert "pool_recycle" not in options
+            options["pool_recycle"] = float(cast("str", query_options.pop("pool_recycle")))
+        options.setdefault("isolation_level", "AUTOCOMMIT")
+        return database_url.replace(options=query_options), options
+
+    @property
+    def engine(self) -> AsyncEngine | None:
+        """Return the live SQLAlchemy async engine, when connected.
+
+        The property exposes the native ``AsyncEngine`` for advanced callers
+        without manufacturing another abstraction. ``None`` means lifecycle has
+        not connected the database yet or has already disconnected it.
+        """
+        return self._engine
+
+    @property
+    def sessionmaker(self) -> async_sessionmaker[AsyncSession] | None:
+        """Return the SQLAlchemy async session factory, when available.
+
+        Saffier creates this with ``async_sessionmaker`` beside the engine.
+        Returning ``None`` before connection makes lifecycle state explicit
+        rather than constructing a hidden engine on property access.
+        """
+        return self._sessionmaker
+
+    async def session(self) -> AsyncSession:
+        """Create a native SQLAlchemy ``AsyncSession``.
+
+        The database must be connected so the session factory is bound to the
+        current ``AsyncEngine``. Sessions use ``expire_on_commit=False`` to keep
+        ORM-facing values usable after transaction boundaries.
+        """
+        await self._ensure_connected()
+        assert self._sessionmaker is not None
+        return self._sessionmaker()
+
+    async def connect_hook(self) -> None:
+        """Run subclass setup before the SQLAlchemy engine is created.
+
+        ``DatabaseTestClient`` uses this hook to create or verify the test
+        database before normal connection proceeds. The base implementation is
+        intentionally empty so regular runtimes connect directly.
+        """
+        pass
+
+    async def disconnect_hook(self) -> None:
+        """Run subclass cleanup after the SQLAlchemy engine is disposed.
+
+        Hooks run after Saffier has closed its force-rollback transaction and
+        disposed the engine, which lets test clients safely drop databases or
+        release resources outside the live connection pool.
+        """
+        pass
+
+    async def connect(self) -> bool:
+        """Create the SQLAlchemy async engine for this database lifecycle.
+
+        Connection is reference-counted because registries and nested async
+        contexts may ask for the same database to connect more than once. The
+        first caller creates ``AsyncEngine`` and ``async_sessionmaker``; later
+        callers reuse that live SQLAlchemy runtime.
+        """
+        async with self.ref_lock:
+            self.ref_counter += 1
+            if self.ref_counter > 1:
+                if bool(self.force_rollback):
+                    await self._ensure_global_force_rollback()
+                return False
+            try:
+                await self.connect_hook()
+                self._engine = create_async_engine(_async_url(self.url), **self.options)
+                self._sessionmaker = async_sessionmaker(
+                    self._engine,
+                    expire_on_commit=False,
+                )
+                self.is_connected = True
+                if bool(self.force_rollback):
+                    await self._ensure_global_force_rollback()
+            except BaseException:
+                self.ref_counter = 0
+                self.is_connected = False
+                self._engine = None
+                self._sessionmaker = None
+                raise
+            return True
+
+    async def disconnect(self, force: bool = False) -> bool:
+        """Dispose the SQLAlchemy async engine when lifecycle ownership ends.
+
+        Normal disconnect decrements the reference counter and only disposes the
+        engine for the last owner. ``force=True`` is reserved for teardown paths
+        that must close the pool regardless of outstanding references.
+        """
+        async with self.ref_lock:
+            if force:
+                self.ref_counter = 0
+            elif self.ref_counter > 0:
+                self.ref_counter -= 1
+            if self.ref_counter > 0:
+                return False
+            if not self.is_connected:
+                return False
+            try:
+                await self._close_global_force_rollback()
+            finally:
+                engine, self._engine = self._engine, None
+                self._sessionmaker = None
+                self.is_connected = False
+                if engine is not None:
+                    await engine.dispose(close=True)
+                await self.disconnect_hook()
+            return True
+
+    async def __aenter__(self) -> Database:
+        """Connect the database for ``async with`` lifecycle management.
+
+        When forced rollback is active, the database is also marked as
+        loop-bound so synchronous lazy-loading bridges re-enter the owning event
+        loop instead of moving SQLAlchemy connections to a helper loop.
+        """
+        await self.connect()
+        if bool(self.force_rollback):
+            self._push_loop_bound_database()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: Any = None,
+    ) -> None:
+        """Disconnect the database at the end of an async context.
+
+        Any loop-bound marker installed for force-rollback mode is removed
+        before the lifecycle reference is released, keeping subsequent sync
+        bridge calls free to use the normal helper-loop path.
+        """
+        del exc_type, exc_value, traceback
+        self._pop_loop_bound_database()
+        await self.disconnect()
+
+    async def _ensure_connected(self) -> None:
+        """Validate that the database has an active SQLAlchemy engine.
+
+        Execution helpers call this before reaching for ``AsyncEngine``. Raising
+        here gives callers a clear lifecycle error instead of a later attribute
+        failure on a missing connection pool.
+        """
+        if not self.is_connected or self._engine is None:
+            raise RuntimeError("Database is not connected")
+
+    def _current_connection(self) -> AsyncConnection | None:
+        """Return the connection currently bound to this execution context.
+
+        Transaction contexts take precedence because nested operations must use
+        the same SQLAlchemy connection. If no transaction is active and forced
+        rollback is enabled, the reusable rollback connection becomes the
+        current connection for test isolation.
+        """
+        stack = _active_connections().get(id(self), ())
+        if stack:
+            return stack[-1]
+        if bool(self.force_rollback):
+            return self._global_connection
+        return None
+
+    def _push_connection(
+        self,
+        connection: AsyncConnection,
+    ) -> Token[dict[int, tuple[AsyncConnection, ...]] | None]:
+        """Bind a SQLAlchemy connection to this database in the current context.
+
+        Bindings are stored as a per-database stack so nested transactions can
+        push savepoint connections and then restore the previous state exactly
+        when they finish.
+        """
+        connections = _active_connections()
+        copied = dict(connections)
+        copied[id(self)] = (*copied.get(id(self), ()), connection)
+        return _ACTIVE_CONNECTIONS.set(copied)
+
+    def _push_loop_bound_database(self) -> None:
+        """Mark this database as using loop-bound SQLAlchemy resources.
+
+        Force-rollback mode keeps one SQLAlchemy connection open across many ORM
+        operations. The sync bridge reads this marker to avoid executing lazy
+        loads on a different event loop from that connection.
+        """
+        databases = _LOOP_BOUND_DATABASES.get()
+        token = _LOOP_BOUND_DATABASES.set((*databases, id(self)))
+        token_stacks = dict(_loop_bound_token_stacks())
+        token_stacks[id(self)] = (*token_stacks.get(id(self), ()), token)
+        _LOOP_BOUND_TOKEN_STACKS.set(token_stacks)
+
+    def _pop_loop_bound_database(self) -> None:
+        """Remove this database's loop-bound marker for the current context.
+
+        The marker token must be reset in the same context that created it.
+        Keeping the stack in a context variable prevents concurrent tasks using
+        the same ``Database`` instance from popping and resetting each other's
+        SQLAlchemy loop markers.
+        """
+        token_stacks = _loop_bound_token_stacks()
+        stack = token_stacks.get(id(self), ())
+        if not stack:
+            return
+        token = stack[-1]
+        copied = dict(token_stacks)
+        if len(stack) == 1:
+            copied.pop(id(self), None)
+        else:
+            copied[id(self)] = stack[:-1]
+        _LOOP_BOUND_TOKEN_STACKS.set(copied)
+        _LOOP_BOUND_DATABASES.reset(token)
+
+    async def _ensure_global_force_rollback(self) -> AsyncConnection:
+        """Open the reusable rollback transaction used for test isolation.
+
+        The connection and transaction are created directly through SQLAlchemy
+        and held for the database lifecycle. ORM statements run against this
+        connection, and disconnect rolls the outer transaction back.
+        """
+        await self._ensure_connected()
+        if self._global_connection is not None:
+            return self._global_connection
+        assert self._engine is not None
+        connection = await self._engine.connect()
+        await connection.execution_options(isolation_level="SERIALIZABLE")
+        transaction = await connection.begin()
+        self._global_connection = connection
+        self._global_transaction = transaction
+        return connection
+
+    async def _close_global_force_rollback(self) -> None:
+        """Roll back and close the force-rollback connection.
+
+        Teardown suppresses rollback errors so disposal can still close the
+        underlying SQLAlchemy connection. This mirrors test cleanup expectations
+        where isolation should be best-effort during exceptional shutdown.
+        """
+        transaction, self._global_transaction = self._global_transaction, None
+        connection, self._global_connection = self._global_connection, None
+        try:
+            if transaction is not None:
+                with contextlib.suppress(Exception):
+                    await transaction.rollback()
+        finally:
+            if connection is not None:
+                await connection.close()
+
+    async def _transaction_connection(self) -> AsyncConnection:
+        """Choose the SQLAlchemy connection for a new transaction scope.
+
+        Existing context connections are reused for nesting, forced rollback
+        scopes reuse the lifecycle-wide rollback connection, and ordinary
+        transactions open a fresh connection from the async engine's pool.
+        """
+        current = self._current_connection()
+        if current is not None:
+            return current
+        if bool(self.force_rollback):
+            return await self._ensure_global_force_rollback()
+        await self._ensure_connected()
+        assert self._engine is not None
+        return await self._engine.connect()
+
+    @contextlib.asynccontextmanager
+    async def connection(self) -> AsyncGenerator[AsyncConnection, None]:
+        """Yield a raw SQLAlchemy ``AsyncConnection`` for direct operations.
+
+        The yielded connection is the current transaction-bound connection when
+        one exists; otherwise a short-lived connection is opened from the
+        ``AsyncEngine`` pool. This keeps direct SQLAlchemy usage aligned with
+        Saffier's transaction context instead of bypassing it.
+        """
+        current = self._current_connection()
+        if current is not None:
+            yield current
+            return
+        await self._ensure_connected()
+        assert self._engine is not None
+        async with self._engine.connect() as connection:
+            yield connection
+
+    @contextlib.asynccontextmanager
+    async def _execution_connection(self) -> AsyncGenerator[AsyncConnection, None]:
+        """Yield the SQLAlchemy connection for one ORM execution helper.
+
+        ORM helpers should not decide whether they are inside a transaction,
+        forced rollback block, or normal engine checkout. This helper centralizes
+        that choice so fetch, execute, and iteration paths all share the same
+        connection ownership rules.
+        """
+        current = self._current_connection()
+        if current is not None:
+            yield current
+            return
+        async with self.connection() as connection:
+            yield connection
+
+    async def fetch_all(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> list[sqlalchemy.Row[Any]]:
+        """Execute a statement and return all rows from SQLAlchemy.
+
+        The method preserves Saffier's public ``fetch_all`` API while routing
+        execution directly through ``AsyncConnection.execute()``. Results are
+        materialized before the cursor is closed so callers can inspect rows
+        after the connection context exits.
+        """
+        del timeout
+        statement = _coerce_statement(query)
+        async with self._execution_connection() as connection:
+            result = await connection.execute(statement, values or {})
+            try:
+                return list(result.fetchall())
+            finally:
+                result.close()
+
+    async def fetch_one(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: dict[str, Any] | None = None,
+        pos: int = 0,
+        timeout: float | None = None,
+    ) -> sqlalchemy.Row[Any] | None:
+        """Execute a statement and return one row by logical position.
+
+        Positive positions are translated into SQLAlchemy ``offset`` and
+        ``limit`` calls when the statement supports them. ``-1`` keeps the
+        historic "last row" behavior by materializing the result and returning
+        the final entry.
+        """
+        del timeout
+        statement = _coerce_statement(query)
+        if pos > 0 and hasattr(statement, "offset"):
+            statement = statement.offset(pos)  # type: ignore[assignment,union-attr]
+        if pos >= 0 and hasattr(statement, "limit"):
+            statement = statement.limit(1)  # type: ignore[assignment,union-attr]
+        rows = await self.fetch_all(statement, values)
+        if not rows:
+            return None
+        if pos == -1:
+            return rows[-1]
+        if pos < -1:
+            raise NotImplementedError(
+                f"Only positive numbers and -1 for the last result are currently supported: {pos}"
+            )
+        return rows[0]
+
+    async def fetch_val(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: dict[str, Any] | None = None,
+        column: int | str = 0,
+        pos: int = 0,
+        timeout: float | None = None,
+    ) -> Any:
+        """Execute a statement and return a single value from one row.
+
+        The value can be selected by integer position or by row mapping key.
+        Returning ``None`` for empty results matches the existing Saffier query
+        helper contract.
+        """
+        row = await self.fetch_one(query, values, pos=pos, timeout=timeout)
+        if row is None:
+            return None
+        if isinstance(column, str):
+            return row._mapping[column]
+        return row[column]
+
+    @staticmethod
+    def _parse_execute_result(result: sqlalchemy.CursorResult[Any]) -> Any:
+        """Convert SQLAlchemy cursor metadata into Saffier's execute result.
+
+        Inserts historically return primary-key metadata when the dialect can
+        provide it, while updates and deletes return ``rowcount``. Keeping this
+        translation in one helper lets ``execute()`` stay SQLAlchemy-native
+        without leaking dialect-specific cursor details throughout the ORM.
+        """
+        if result.is_insert:
+            with contextlib.suppress(AttributeError):
+                inserted_primary_key = result.inserted_primary_key
+                if inserted_primary_key:
+                    return inserted_primary_key
+            with contextlib.suppress(AttributeError):
+                return result.lastrowid
+        return result.rowcount
+
+    async def execute(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: Any = None,
+        timeout: float | None = None,
+    ) -> Any:
+        """Execute one SQLAlchemy statement and return the public result value.
+
+        Statements are run through the current execution connection, which means
+        they participate in active Saffier transactions and force-rollback test
+        contexts. The returned value follows the legacy Saffier contract:
+        insert metadata when available, otherwise affected row count.
+        """
+        del timeout
+        statement = _coerce_statement(query)
+        async with self._execution_connection() as connection:
+            result = (
+                await connection.execute(statement, values)
+                if values is not None
+                else await connection.execute(statement)
+            )
+            try:
+                return self._parse_execute_result(result)
+            finally:
+                result.close()
+
+    async def execute_many(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: Any = None,
+        timeout: float | None = None,
+    ) -> Any:
+        """Execute one statement against many parameter dictionaries.
+
+        SQLAlchemy handles executemany behavior when a sequence of parameter
+        dictionaries is passed to ``execute()``. Saffier only adapts the cursor
+        metadata back into the value expected by bulk insert and update code.
+        """
+        del timeout
+        statement = _coerce_statement(query)
+        async with self._execution_connection() as connection:
+            result = (
+                await connection.execute(statement, values)
+                if values is not None
+                else await connection.execute(statement)
+            )
+            try:
+                if result.is_insert:
+                    with contextlib.suppress(AttributeError):
+                        if result.inserted_primary_key_rows is not None:
+                            return result.inserted_primary_key_rows
+                return result.rowcount
+            finally:
+                result.close()
+
+    async def iterate(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: dict[str, Any] | None = None,
+        chunk_size: int | None = None,
+        timeout: float | None = None,
+    ) -> AsyncGenerator[sqlalchemy.Row[Any], None]:
+        """Yield rows from a SQLAlchemy statement without hiding result objects.
+
+        Dialects with server-side cursor support use ``AsyncConnection.stream``
+        and ``yield_per`` when a transaction is already active. Dialects without
+        streaming support, or autocommit connections where asyncpg cannot open a
+        cursor, fall back to a materialized result while preserving the async
+        generator API.
+        """
+        del timeout
+        statement = _coerce_statement(query)
+        chunk_size = chunk_size or self.default_batch_size
+        async with self._execution_connection() as connection:
+            if (
+                not connection.dialect.supports_server_side_cursors
+                or not connection.in_transaction()
+            ):
+                result = await connection.execute(statement, values or {})
+                try:
+                    for row in result.fetchall():
+                        yield row
+                finally:
+                    result.close()
+                return
+
+            await connection.execution_options(yield_per=chunk_size)
+            try:
+                async with connection.stream(statement, values or {}) as result:
+                    async for row in result:
+                        yield row
+            finally:
+                await connection.execution_options(yield_per=0)
+
+    async def batched_iterate(
+        self,
+        query: sqlalchemy.ClauseElement | str,
+        values: dict[str, Any] | None = None,
+        batch_size: int | None = None,
+        batch_wrapper: Callable[[Sequence[Any]], Any] = tuple,
+        timeout: float | None = None,
+    ) -> AsyncGenerator[Any, None]:
+        """Yield result rows grouped into caller-configured batches.
+
+        This compatibility helper materializes rows with ``fetch_all`` and then
+        wraps each batch with ``batch_wrapper``. The execution itself still uses
+        SQLAlchemy async connections and participates in active transactions.
+        """
+        del timeout
+        batch_size = batch_size or self.default_batch_size
+        rows = await self.fetch_all(query, values)
+        for batch in _batch_rows(rows, batch_size):
+            yield batch_wrapper(batch)
+
+    def transaction(self, *, force_rollback: bool = False, **kwargs: Any) -> Transaction:
+        """Create a SQLAlchemy-backed Saffier transaction context.
+
+        Keyword arguments are passed through as SQLAlchemy execution options
+        before the transaction begins. The returned object supports ``async
+        with``, manual ``await`` startup, and decorator usage.
+        """
+        return Transaction(self, force_rollback=force_rollback, **kwargs)
+
+    async def run_sync(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run a synchronous SQLAlchemy callable against an async connection.
+
+        SQLAlchemy exposes ``AsyncConnection.run_sync()`` for operations such as
+        metadata creation and reflection that still use synchronous Core APIs.
+        Saffier forwards directly to that method so schema helpers remain
+        idiomatic SQLAlchemy 2.x async code.
+        """
+        del timeout
+        async with self._execution_connection() as connection:
+            return await connection.run_sync(fn, *args, **kwargs)
+
+    async def create_all(
+        self,
+        meta: sqlalchemy.MetaData,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Create every table in a SQLAlchemy ``MetaData`` object.
+
+        Table creation is executed through ``AsyncConnection.run_sync()`` so the
+        synchronous ``MetaData.create_all`` API runs on the connection paired
+        with the active async engine or transaction.
+        """
+        del timeout
+        await self.run_sync(meta.create_all, **kwargs)
+
+    async def drop_all(
+        self,
+        meta: sqlalchemy.MetaData,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Drop every table in a SQLAlchemy ``MetaData`` object.
+
+        The method mirrors ``create_all`` and keeps Saffier schema teardown on
+        SQLAlchemy's public metadata API. Any active transaction or
+        force-rollback connection is respected by the execution connection.
+        """
+        del timeout
+        await self.run_sync(meta.drop_all, **kwargs)
+
+    def asgi(
+        self,
+        app: ASGIApp | None = None,
+        handle_lifespan: bool = False,
+    ) -> ASGIApp | Callable[[ASGIApp], ASGIApp]:
+        """Wrap an ASGI application with SQLAlchemy engine lifecycle hooks.
+
+        The wrapper connects the database during ASGI startup and registers
+        ``disconnect`` as cleanup. This keeps framework integration small while
+        still ensuring SQLAlchemy pools are opened and disposed at application
+        lifecycle boundaries.
+        """
+        if LifespanHook is None:
+            raise RuntimeError("monkay.asgi is required for ASGI integration.")
+
+        async def setup() -> contextlib.AsyncExitStack:
+            """Connect the database and register ASGI lifespan cleanup.
+
+            ``LifespanHook`` expects a stack-like object that owns async cleanup
+            callbacks. Saffier connects the SQLAlchemy engine first and then
+            pushes ``disconnect`` so pool disposal always runs on shutdown.
+            """
+            cleanupstack = contextlib.AsyncExitStack()
+            await self.connect()
+            cleanupstack.push_async_callback(self.disconnect)
+            return cleanupstack
+
+        return LifespanHook(app, setup=setup, do_forward=not handle_lifespan)
+
+
+class DatabaseTestClient(Database):
+    """Testing database runtime built directly on SQLAlchemy Async.
+
+    The client rewrites the configured database name with a test prefix and can
+    create, reuse, or drop that database for test runs. It inherits the normal
+    SQLAlchemy-backed ``Database`` execution and transaction behavior.
+    """
+
+    testclient_operation_timeout: float = 4
+    testclient_operation_timeout_init: float = 8
+    testclient_default_full_isolation: bool = True
+    testclient_default_force_rollback: bool = False
+    testclient_default_lazy_setup: bool = False
+    testclient_default_use_existing: bool = False
+    testclient_default_drop_database: bool = False
+    testclient_default_test_prefix: str = "test_"
+
+    def __init__(
+        self,
+        url: str | DatabaseURL | URL | Database | None = None,
+        *,
+        force_rollback: bool | None = None,
+        full_isolation: bool | None = None,
+        use_existing: bool | None = None,
+        drop_database: bool | None = None,
+        lazy_setup: bool | None = None,
+        test_prefix: str | None = None,
+        **options: Any,
+    ) -> None:
+        """Prepare the test database URL and setup policy.
+
+        The client rewrites the target database name with the configured test
+        prefix unless an empty prefix is requested. Setup may run immediately in
+        synchronous construction contexts or be deferred to ``connect()`` when
+        construction happens inside an event loop.
+        """
+        if use_existing is None:
+            use_existing = self.testclient_default_use_existing
+        if drop_database is None:
+            drop_database = self.testclient_default_drop_database
+        if full_isolation is None:
+            full_isolation = self.testclient_default_full_isolation
+        if test_prefix is None:
+            test_prefix = self.testclient_default_test_prefix
+        if force_rollback is None:
+            force_rollback = self.testclient_default_force_rollback
+        if lazy_setup is None:
+            lazy_setup = self.testclient_default_lazy_setup
+
+        self.use_existing = use_existing
+        self.drop = drop_database
+        self._setup_executed_init = False
+
+        source_database = url if isinstance(url, Database) else None
+        super().__init__(
+            url,
+            force_rollback=force_rollback,
+            full_isolation=full_isolation,
+            **options,
+        )
+        if source_database is not None and hasattr(source_database, "test_db_url"):
+            self.test_db_url = source_database.test_db_url
+        else:
+            if test_prefix:
+                self.url = self.url.replace(database=f"{test_prefix}{self.url.database}")
+            self.test_db_url = str(self.url)
+
+        if not lazy_setup:
+            self.setup_protected(self.testclient_operation_timeout_init)
+            self._setup_executed_init = True
+
+    async def setup(self) -> None:
+        """Create or refresh the configured test database.
+
+        Existing databases are dropped unless ``use_existing`` is enabled. All
+        create/drop work goes through SQLAlchemy async connections so the test
+        client no longer relies on an external database utility layer.
+        """
+        db_exists = await self.database_exists(self.test_db_url)
+        if not self.use_existing:
+            try:
+                if db_exists:
+                    await self.drop_database(self.test_db_url)
+                await self.create_database(self.test_db_url)
+            except (ProgrammingError, OperationalError, TypeError):
+                self.drop = False
+        elif not db_exists:
+            try:
+                await self.create_database(self.test_db_url)
+            except (ProgrammingError, OperationalError):
+                self.drop = False
+
+    def setup_protected(self, operation_timeout: float) -> None:
+        """Run constructor-time setup only when it is legal to block.
+
+        Some tests instantiate the client at module import time, where no event
+        loop is running and ``asyncio.run`` is safe. If construction happens
+        inside a running loop, setup is deferred to ``connect_hook`` so callers
+        do not hit nested-loop errors.
+        """
+        del operation_timeout
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            with contextlib.suppress(TimeoutError):
+                asyncio.run(self.setup())
+        else:
+            # Constructors can be called from an async test module. Defer setup
+            # to connect() where awaiting is legal.
+            return
+
+    async def connect_hook(self) -> None:
+        """Ensure lazy test database setup has run before engine creation.
+
+        ``Database.connect()`` calls this hook immediately before creating the
+        SQLAlchemy ``AsyncEngine``. Running setup here guarantees the target
+        database exists before the pool attempts its first connection.
+        """
+        if not self._setup_executed_init:
+            await self.setup()
+            self._setup_executed_init = True
+        await super().connect_hook()
+
+    async def disconnect_hook(self) -> None:
+        """Drop the test database after the SQLAlchemy engine is disposed.
+
+        Dropping happens after disconnect so no pooled SQLAlchemy connections
+        remain open against the database being removed. The setup flag is reset
+        so a later reconnect can recreate or verify the database again.
+        """
+        self._setup_executed_init = False
+        if self.drop:
+            await self.drop_database(self.test_db_url)
+        await super().disconnect_hook()
+
+    async def is_database_exist(self) -> Any:
+        """Return whether this client's configured test database exists.
+
+        The method keeps the historical public spelling while delegating to the
+        SQLAlchemy-native class-level probe. It is useful for tests that assert
+        setup and teardown behavior directly.
+        """
+        return await self.database_exists(self.test_db_url)
+
+    @classmethod
+    async def database_exists(cls, url: str | URL | DatabaseURL) -> bool:
+        """Check database existence using SQLAlchemy async connections.
+
+        SQLite is checked through the filesystem because a missing file is the
+        database state. PostgreSQL and MySQL probe administrative catalogs from
+        fallback databases so the target database can be checked even when it
+        does not yet accept connections.
+        """
+        database_url = url if isinstance(url, DatabaseURL) else DatabaseURL(url)
+        database = database_url.database
+        dialect_name = database_url.sqla_url.get_dialect(True).name
+        if dialect_name == "sqlite":
+            return not database or database == ":memory:" or os.path.exists(database)
+
+        if dialect_name == "postgresql":
+            text = sqlalchemy.text("SELECT 1 FROM pg_database WHERE datname=:database")
+            for candidate in (database, "postgres", "template1", "template0", None):
+                try:
+                    probe_url = database_url.replace(database=candidate)
+                    async with Database(
+                        probe_url, force_rollback=False, full_isolation=False
+                    ) as db:
+                        statement = sqlalchemy.text("SELECT 1") if candidate == database else text
+                        values = None if candidate == database else {"database": database}
+                        if await db.fetch_val(statement, values):
+                            return True
+                except Exception:
+                    pass
+            return False
+
+        if dialect_name == "mysql":
+            text = sqlalchemy.text(
+                "SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = :database"
+            )
+            for candidate in (database, None, "mysql"):
+                try:
+                    probe_url = database_url.replace(database=candidate)
+                    async with Database(
+                        probe_url, force_rollback=False, full_isolation=False
+                    ) as db:
+                        statement = sqlalchemy.text("SELECT 1") if candidate == database else text
+                        values = None if candidate == database else {"database": database}
+                        if await db.fetch_val(statement, values):
+                            return True
+                except Exception:
+                    pass
+            return False
+
+        try:
+            async with Database(database_url, force_rollback=False, full_isolation=False) as db:
+                await db.fetch_val(sqlalchemy.text("SELECT 1"))
+                return True
+        except Exception:
+            return False
+
+    @classmethod
+    def _resolve_admin_url(cls, url: str | URL | DatabaseURL) -> tuple[DatabaseURL, str, str, str]:
+        """Resolve the administrative connection target for database DDL.
+
+        Creating or dropping a database usually cannot be done while connected
+        to that same database. This helper returns a SQLAlchemy-compatible URL
+        for the dialect's administrative database, the original database name,
+        and dialect metadata used by create/drop helpers.
+        """
+        database_url = url if isinstance(url, DatabaseURL) else DatabaseURL(url)
+        database = database_url.database
+        dialect = database_url.sqla_url.get_dialect(True)
+        dialect_name = dialect.name
+        dialect_driver = dialect.driver
+        if dialect_name == "postgresql":
+            database_url = database_url.replace(database="postgres")
+        elif dialect_name == "mssql":
+            database_url = database_url.replace(database="master")
+        elif dialect_name == "cockroachdb":
+            database_url = database_url.replace(database="defaultdb")
+        elif dialect_name != "sqlite":
+            database_url = database_url.replace(database=None)
+        return database_url, database, dialect_name, dialect_driver
+
+    @staticmethod
+    def _sanitize_charset_name(value: str) -> str:
+        """Validate an encoding identifier before it is interpolated into DDL.
+
+        SQLAlchemy bind parameters cannot represent identifiers or charset names
+        in all dialect DDL forms. Restricting the value to alphanumerics and
+        underscores prevents crafted input from becoming executable SQL.
+        """
+        if not re.fullmatch(r"[A-Za-z0-9_]+", value):
+            raise ValueError(f"Invalid encoding name: {value!r}")
+        return value
+
+    @staticmethod
+    def _quote_identifier(connection: AsyncConnection, identifier: str) -> str:
+        """Quote a database identifier with the active SQLAlchemy dialect.
+
+        Database names are identifiers, not values, so they cannot be safely
+        passed as bind parameters in ``CREATE DATABASE`` or ``DROP DATABASE``.
+        SQLAlchemy's dialect preparer supplies the correct quoting rules for
+        the live connection.
+        """
+        return connection.sync_connection.dialect.identifier_preparer.quote(identifier)
+
+    @classmethod
+    async def create_database(
+        cls,
+        url: str | URL | DatabaseURL,
+        encoding: str = "utf8",
+        template: str | None = None,
+    ) -> None:
+        """Create a database through dialect-appropriate SQLAlchemy DDL.
+
+        The method connects to an administrative database resolved from the
+        target URL, quotes identifiers through SQLAlchemy, and emits the minimum
+        dialect-specific DDL needed for PostgreSQL, MySQL, SQLite, and generic
+        SQLAlchemy-supported databases.
+        """
+        database_url, database, dialect_name, _ = cls._resolve_admin_url(url)
+        if dialect_name == "sqlite":
+            if database and database != ":memory:":
+                async with Database(
+                    database_url, force_rollback=False, full_isolation=False
+                ) as db:
+                    await db.execute(sqlalchemy.text("CREATE TABLE _dropme_DB(id int)"))
+                    await db.execute(sqlalchemy.text("DROP TABLE _dropme_DB"))
+            return
+
+        async with (
+            Database(database_url, force_rollback=False, full_isolation=False) as db,
+            db.connection() as connection,
+        ):
+            quote = cls._quote_identifier(connection, database)
+            if dialect_name == "postgresql":
+                encoding = cls._sanitize_charset_name(encoding)
+                template = template or "template1"
+                template = cls._quote_identifier(connection, template)
+                await connection.execute(
+                    sqlalchemy.text(
+                        f"CREATE DATABASE {quote} ENCODING '{encoding}' TEMPLATE {template}"
+                    )
+                )
+            elif dialect_name == "mysql":
+                encoding = cls._sanitize_charset_name(encoding)
+                await connection.execute(
+                    sqlalchemy.text(f"CREATE DATABASE {quote} CHARACTER SET {encoding}")
+                )
+            else:
+                await connection.execute(sqlalchemy.text(f"CREATE DATABASE {quote}"))
+
+    @classmethod
+    async def drop_database(
+        cls,
+        url: str | URL | DatabaseURL,
+        *,
+        use_if_exists: bool = True,
+    ) -> None:
+        """Drop a database through dialect-appropriate SQLAlchemy DDL.
+
+        SQLite teardown removes the database file. PostgreSQL teardown first
+        terminates other sessions connected to the target database before
+        issuing ``DROP DATABASE`` from an administrative connection.
+        """
+        database_url, database, dialect_name, _ = cls._resolve_admin_url(url)
+        if dialect_name == "sqlite":
+            if database and database != ":memory:":
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(database)
+            return
+
+        exists_text = "IF EXISTS " if use_if_exists else ""
+        async with (
+            Database(database_url, force_rollback=False, full_isolation=False) as db,
+            db.connection() as connection,
+        ):
+            quote = cls._quote_identifier(connection, database)
+            if dialect_name.startswith("postgres"):
+                server_version = cast(
+                    str,
+                    await db.fetch_val(
+                        sqlalchemy.text(
+                            "SELECT setting FROM pg_settings WHERE name = 'server_version'"
+                        )
+                    ),
+                ).split(" ")[0]
+                version = tuple(map(int, server_version.split(".")[:2]))
+                pid_column = "pid" if version >= (9, 2) else "procpid"
+                await connection.execute(
+                    sqlalchemy.text(
+                        f"""
+                        SELECT pg_terminate_backend(pg_stat_activity.{pid_column})
+                        FROM pg_stat_activity
+                        WHERE pg_stat_activity.datname = :database
+                        AND {pid_column} <> pg_backend_pid()
+                        """
+                    ),
+                    {"database": database},
+                )
+            with contextlib.suppress(ProgrammingError):
+                await connection.execute(sqlalchemy.text(f"DROP DATABASE {exists_text}{quote}"))
+
+
+SaffierTestClient = DatabaseTestClient
+
+__all__ = [
+    "ACTIVE_FORCE_ROLLBACKS",
+    "Database",
+    "DatabaseTestClient",
+    "DatabaseURL",
+    "ForceRollback",
+    "SaffierTestClient",
+    "Transaction",
+    "should_reenter_sync_bridge",
+]

--- a/saffier/core/db/models/model.py
+++ b/saffier/core/db/models/model.py
@@ -19,7 +19,7 @@ from saffier.core.db.models.mixins.generics import DeclarativeMixin
 from saffier.core.db.models.row import ModelRow
 from saffier.core.utils.db import check_db_connection
 from saffier.core.utils.schemas import Schema
-from saffier.core.utils.sync import run_sync
+from saffier.core.utils.sync import force_current_loop_for_sqlalchemy, run_sync
 
 saffier_setattr = object.__setattr__
 
@@ -825,7 +825,8 @@ class Model(ModelRow, DeclarativeMixin, AdminMixin):
                 raise AttributeError(name)
             if name in getattr(self, "__no_load_trigger_attrs__", set()):
                 raise AttributeError(name)
-            run_sync(self.load())
+            with force_current_loop_for_sqlalchemy():
+                run_sync(self.load())
             return self.__dict__[name]
         raise AttributeError(name)
 

--- a/saffier/core/db/models/row.py
+++ b/saffier/core/db/models/row.py
@@ -5,7 +5,7 @@ from sqlalchemy.engine.result import Row
 
 from saffier.core.db import fields as saffier_fields
 from saffier.core.db.models.base import SaffierBaseModel
-from saffier.core.utils.sync import run_sync
+from saffier.core.utils.sync import force_current_loop_for_sqlalchemy, run_sync
 from saffier.exceptions import QuerySetError
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -616,13 +616,14 @@ class ModelRow(SaffierBaseModel):
                 if isinstance(
                     cls.fields.get(first_part), saffier_fields.ManyToManyField
                 ) or hasattr(model, first_part):
-                    records = run_sync(
-                        cls.__collect_prefetch_records(
-                            model=model,
-                            related_name=related.related_name,
-                            queryset=original_prefetch.queryset,
+                    with force_current_loop_for_sqlalchemy():
+                        records = run_sync(
+                            cls.__collect_prefetch_records(
+                                model=model,
+                                related_name=related.related_name,
+                                queryset=original_prefetch.queryset,
+                            )
                         )
-                    )
                     saffier_setattr(model, related.to_attr, records)
                     continue
 
@@ -650,19 +651,21 @@ class ModelRow(SaffierBaseModel):
                 related.queryset.extra = extra
 
                 # Execute the queryset
-                records = run_sync(cls.__run_query(queryset=related.queryset))
+                with force_current_loop_for_sqlalchemy():
+                    records = run_sync(cls.__run_query(queryset=related.queryset))
                 saffier_setattr(model, related.to_attr, records)
             elif isinstance(
                 cls.fields.get(related.related_name),
                 saffier_fields.ManyToManyField,
             ) or hasattr(model, related.related_name):
-                records = run_sync(
-                    cls.__collect_prefetch_records(
-                        model=model,
-                        related_name=related.related_name,
-                        queryset=related.queryset,
+                with force_current_loop_for_sqlalchemy():
+                    records = run_sync(
+                        cls.__collect_prefetch_records(
+                            model=model,
+                            related_name=related.related_name,
+                            queryset=related.queryset,
+                        )
                     )
-                )
                 saffier_setattr(model, related.to_attr, records)
             else:
                 model_cls = getattr(cls, related.related_name).related_from
@@ -820,7 +823,8 @@ class ModelRow(SaffierBaseModel):
 
         extra = cls._build_related_pk_filter(query, row, parent_cls)
 
-        records = run_sync(cls.__run_query(model_class, extra, queryset))
+        with force_current_loop_for_sqlalchemy():
+            records = run_sync(cls.__run_query(model_class, extra, queryset))
         return records
 
     @classmethod

--- a/saffier/core/db/querysets/clauses.py
+++ b/saffier/core/db/querysets/clauses.py
@@ -9,7 +9,7 @@ from saffier.core.db import fields as saffier_fields
 from saffier.core.db.relationships.related import RelatedField
 from saffier.core.db.relationships.utils import crawl_relationship
 from saffier.core.utils.db import hash_tablekey
-from saffier.core.utils.sync import run_sync
+from saffier.core.utils.sync import force_current_loop_for_sqlalchemy, run_sync
 
 DEFAULT_ESCAPE_CHARACTERS = ("%", "_")
 
@@ -104,16 +104,20 @@ def build_lookup_clauses(
                     **{crawl_result.cross_db_remainder: value}
                 )
                 if len(remote_fields) == 1:
-                    sub_results = run_sync(
-                        sub_queryset.values_list(fields=[remote_fields[0]], flat=True)
-                    )
+                    with force_current_loop_for_sqlalchemy():
+                        sub_results = run_sync(
+                            sub_queryset.values_list(fields=[remote_fields[0]], flat=True)
+                        )
                     clauses.append(
                         table.columns[
                             relation_field.get_column_names(crawl_result.field_name)[0]
                         ].in_(sub_results)
                     )
                 else:
-                    sub_results = run_sync(sub_queryset.values_list(fields=list(remote_fields)))
+                    with force_current_loop_for_sqlalchemy():
+                        sub_results = run_sync(
+                            sub_queryset.values_list(fields=list(remote_fields))
+                        )
                     clauses.append(
                         _build_composite_in_clause(
                             [

--- a/saffier/core/utils/sync.py
+++ b/saffier/core/utils/sync.py
@@ -1,18 +1,63 @@
+"""Synchronous bridge helpers for Saffier's async SQLAlchemy runtime.
+
+Saffier exposes ``run_sync`` for applications and tests that need to call async
+ORM APIs from synchronous code. The bridge normally moves work to a helper event
+loop, but SQLAlchemy async connections are loop-bound, so active transaction
+contexts must be re-entered on their owning loop.
+"""
+
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import weakref
-from collections.abc import Awaitable
-from contextvars import ContextVar, copy_context
+from collections.abc import Awaitable, Iterator
+from contextvars import ContextVar, Token, copy_context
 from threading import Event, Thread
 from typing import Any
 
 current_eventloop: ContextVar[asyncio.AbstractEventLoop | None] = ContextVar(
     "current_eventloop", default=None
 )
+_SQLALCHEMY_SYNC_BRIDGE_DEPTH: ContextVar[int] = ContextVar(
+    "_SQLALCHEMY_SYNC_BRIDGE_DEPTH", default=0
+)
+
+
+@contextlib.contextmanager
+def force_current_loop_for_sqlalchemy() -> Iterator[None]:
+    """Force ``run_sync`` to execute the awaitable on the current loop.
+
+    SQLAlchemy async engines and driver connections are bound to the event loop
+    that created or checked them out. ORM lazy-loading paths use this context
+    when synchronous attribute access has to await database work from inside an
+    already-running loop.
+    """
+    token: Token[int] = _SQLALCHEMY_SYNC_BRIDGE_DEPTH.set(_SQLALCHEMY_SYNC_BRIDGE_DEPTH.get() + 1)
+    try:
+        yield
+    finally:
+        _SQLALCHEMY_SYNC_BRIDGE_DEPTH.reset(token)
+
+
+def should_force_current_loop_for_sqlalchemy() -> bool:
+    """Return whether the current ``run_sync`` call is SQLAlchemy-bound.
+
+    The flag is deliberately explicit instead of applying to every nested
+    ``run_sync`` call. Generic synchronous bridge calls still use the helper
+    loop, while ORM database lazy loads stay on the loop that owns SQLAlchemy's
+    async resources.
+    """
+    return _SQLALCHEMY_SYNC_BRIDGE_DEPTH.get() > 0
 
 
 async def _coro_helper(awaitable: Awaitable, timeout: float | None) -> Any:
+    """Await one object while applying Saffier's optional timeout behavior.
+
+    The helper keeps timeout handling identical across direct ``asyncio.run``,
+    inactive-loop ``run_until_complete``, helper-loop execution, and re-entered
+    SQLAlchemy transaction loops.
+    """
     if timeout is not None and timeout > 0:
         return await asyncio.wait_for(awaitable, timeout)
     return await awaitable
@@ -24,6 +69,12 @@ weak_subloop_map: weakref.WeakKeyDictionary[
 
 
 async def _startup(old_loop: asyncio.AbstractEventLoop, is_initialized: Event) -> None:
+    """Register a helper loop that lives as long as its parent loop.
+
+    Saffier's traditional sync bridge uses a background event loop per active
+    parent loop. The helper is recorded in ``weak_subloop_map`` and stops itself
+    once the parent loop closes.
+    """
     new_loop = asyncio.get_running_loop()
     weakref.finalize(old_loop, new_loop.stop)
     weak_subloop_map[old_loop] = new_loop
@@ -37,6 +88,12 @@ async def _startup(old_loop: asyncio.AbstractEventLoop, is_initialized: Event) -
 
 
 def _init_thread(old_loop: asyncio.AbstractEventLoop, is_initialized: Event) -> None:
+    """Create and run the background helper loop for a parent event loop.
+
+    This function is the target for a daemon thread. It publishes the helper
+    loop through ``_startup()``, runs it until shutdown, then closes async
+    generators and removes the weak-map entry during cleanup.
+    """
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     task = loop.create_task(_startup(old_loop, is_initialized))
@@ -56,6 +113,12 @@ def _init_thread(old_loop: asyncio.AbstractEventLoop, is_initialized: Event) -> 
 
 
 def get_subloop(loop: asyncio.AbstractEventLoop) -> asyncio.AbstractEventLoop:
+    """Return the helper event loop paired with a parent loop.
+
+    A helper loop is created lazily on first use and then reused for later sync
+    bridge calls. Reuse avoids repeatedly starting threads while preserving the
+    old context-copying behavior for non-SQLAlchemy-bound calls.
+    """
     sub_loop = weak_subloop_map.get(loop)
     if sub_loop is None:
         is_initialized = Event()
@@ -74,6 +137,12 @@ def run_sync(
 ) -> Any:
     """
     Runs an awaitable from synchronous code, reusing or bridging event loops when needed.
+
+    When SQLAlchemy async connections are bound to the current context, Saffier
+    re-enters the running loop instead of copying context into a helper loop.
+    This keeps loop-bound SQLAlchemy transactions and asyncpg futures on the
+    loop that owns them while preserving the helper-loop behavior for unrelated
+    synchronous bridge calls.
     """
     if loop is None:
         try:
@@ -84,6 +153,25 @@ def run_sync(
     if loop is None:
         return asyncio.run(_coro_helper(awaitable, timeout))
     if not loop.is_closed() and not loop.is_running():
+        return loop.run_until_complete(_coro_helper(awaitable, timeout))
+    if not loop.is_closed():
+        try:
+            from saffier.core.connection.database import should_reenter_sync_bridge
+        except Exception:
+            should_reenter = False
+        else:
+            should_reenter = (
+                should_force_current_loop_for_sqlalchemy() or should_reenter_sync_bridge()
+            )
+        if not should_reenter:
+            ctx = copy_context()
+            return asyncio.run_coroutine_threadsafe(
+                ctx.run(_coro_helper, awaitable, timeout), get_subloop(loop)
+            ).result()
+
+        import nest_asyncio
+
+        nest_asyncio.apply(loop)
         return loop.run_until_complete(_coro_helper(awaitable, timeout))
 
     ctx = copy_context()

--- a/saffier/core/utils/sync.py
+++ b/saffier/core/utils/sync.py
@@ -11,10 +11,28 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import weakref
-from collections.abc import Awaitable, Iterator
+from collections.abc import Awaitable, Iterable, Iterator
 from contextvars import ContextVar, Token, copy_context
 from threading import Event, Thread
 from typing import Any
+
+_MISSING: Any = object()
+_LOOP_REENTRY_ATTRS = (
+    "run_forever",
+    "run_until_complete",
+    "_run_once",
+    "_check_running",
+    "_check_runnung",
+    "_num_runs_pending",
+    "_is_proactorloop",
+    "_nest_patched",
+)
+_ASYNCIO_REENTRY_ATTRS = (
+    (asyncio, ("Task", "Future", "run", "get_event_loop", "_nest_patched")),
+    (asyncio.tasks, ("Task", "_CTask", "_current_tasks")),
+    (asyncio.futures, ("Future", "_CFuture")),
+    (asyncio.events, ("get_event_loop", "_get_event_loop")),
+)
 
 current_eventloop: ContextVar[asyncio.AbstractEventLoop | None] = ContextVar(
     "current_eventloop", default=None
@@ -49,6 +67,85 @@ def should_force_current_loop_for_sqlalchemy() -> bool:
     async resources.
     """
     return _SQLALCHEMY_SYNC_BRIDGE_DEPTH.get() > 0
+
+
+def _snapshot_attrs(target: Any, names: Iterable[str]) -> tuple[tuple[Any, str, Any], ...]:
+    """Capture object attributes before a temporary asyncio re-entry patch.
+
+    ``nest_asyncio`` makes both module-level and event-loop-class changes. The
+    sync bridge only needs those changes while one SQLAlchemy-bound coroutine is
+    being driven to completion, so Saffier records every attribute that may be
+    touched before applying the patch.
+
+    Args:
+        target: Module, class, or object whose attributes should be captured.
+        names: Attribute names that may be replaced or created by the patch.
+
+    Returns:
+        tuple[tuple[Any, str, Any], ...]: Snapshot entries containing the target,
+        attribute name, and previous value. A private sentinel is stored when
+        the attribute did not exist so restoration can delete patch-created
+        attributes instead of leaving false state behind.
+    """
+    return tuple((target, name, getattr(target, name, _MISSING)) for name in names)
+
+
+def _restore_attrs(snapshot: Iterable[tuple[Any, str, Any]]) -> None:
+    """Restore attributes captured by ``_snapshot_attrs()``.
+
+    Restoration is deliberately value-based instead of assuming the unpatched
+    stdlib shape. That matters in embedded environments, test harnesses, and
+    interactive shells where another tool may already have installed a custom
+    event-loop policy or task implementation before Saffier enters the bridge.
+
+    Args:
+        snapshot: Entries returned by ``_snapshot_attrs()``.
+    """
+    for target, name, value in snapshot:
+        if value is _MISSING:
+            with contextlib.suppress(AttributeError):
+                delattr(target, name)
+        else:
+            setattr(target, name, value)
+
+
+@contextlib.contextmanager
+def _temporary_loop_reentry(loop: asyncio.AbstractEventLoop) -> Iterator[None]:
+    """Temporarily allow one running event loop to be re-entered.
+
+    SQLAlchemy async connections and asyncpg driver objects are tied to the
+    event loop that owns them. When synchronous ORM surfaces such as deferred
+    attribute access need to await work while a transaction-bound connection is
+    active, moving the coroutine to Saffier's helper loop would cross event-loop
+    ownership and fail.
+
+    ``nest_asyncio`` provides the required re-entry mechanics, but its public
+    ``apply()`` function also changes the event-loop policy and leaves all
+    mutations in place. Python 3.14 exposes that as a hard failure because
+    asyncpg uses ``asyncio.timeout()``, which now requires
+    ``asyncio.current_task()`` to remain visible while callbacks run. This
+    context manager uses only the patch pieces needed for one nested
+    ``run_until_complete()`` call and restores the previous loop, task, future,
+    and ``asyncio.run()`` state before normal async execution resumes.
+
+    Args:
+        loop: Running event loop that owns the SQLAlchemy resources being used
+            by the synchronous bridge.
+    """
+    import nest_asyncio
+
+    loop_snapshot = _snapshot_attrs(loop.__class__, _LOOP_REENTRY_ATTRS)
+    asyncio_snapshot: list[tuple[Any, str, Any]] = []
+    for target, names in _ASYNCIO_REENTRY_ATTRS:
+        asyncio_snapshot.extend(_snapshot_attrs(target, names))
+
+    try:
+        nest_asyncio._patch_asyncio()
+        nest_asyncio._patch_loop(loop)
+        yield
+    finally:
+        _restore_attrs(asyncio_snapshot)
+        _restore_attrs(loop_snapshot)
 
 
 async def _coro_helper(awaitable: Awaitable, timeout: float | None) -> Any:
@@ -169,10 +266,8 @@ def run_sync(
                 ctx.run(_coro_helper, awaitable, timeout), get_subloop(loop)
             ).result()
 
-        import nest_asyncio
-
-        nest_asyncio.apply(loop)
-        return loop.run_until_complete(_coro_helper(awaitable, timeout))
+        with _temporary_loop_reentry(loop):
+            return loop.run_until_complete(_coro_helper(awaitable, timeout))
 
     ctx = copy_context()
     return asyncio.run_coroutine_threadsafe(

--- a/saffier/protocols/transaction_call.py
+++ b/saffier/protocols/transaction_call.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from databasez.core.transaction import Transaction
+    from saffier.core.connection.database import Transaction
 
 
 class TransactionCallProtocol(Protocol):

--- a/saffier/testclient.py
+++ b/saffier/testclient.py
@@ -1,16 +1,24 @@
+"""Public test client entry point for Saffier's SQLAlchemy Async runtime.
+
+The concrete implementation lives beside the database runtime so test database
+creation, rollback behavior, and engine lifecycle share one SQLAlchemy-native
+code path. This module keeps the historical import path and environment-default
+configuration used by applications and Saffier's own tests.
+"""
+
 import os
 import typing
 from typing import TYPE_CHECKING, Any
 
-from databasez.testclient import DatabaseTestClient as _DatabaseTestClient
+from saffier.core.connection.database import DatabaseTestClient as _DatabaseTestClient
 
 if TYPE_CHECKING:
     import sqlalchemy
-    from databasez import Database, DatabaseURL
 
-# TODO: move this to the settings
+    from saffier.core.connection.database import Database, DatabaseURL
+
+
 default_test_prefix: str = "test_"
-# for allowing empty
 if "SAFFIER_TESTCLIENT_TEST_PREFIX" in os.environ:
     default_test_prefix = os.environ["SAFFIER_TESTCLIENT_TEST_PREFIX"]
 
@@ -24,9 +32,12 @@ default_drop_database: bool = (
 
 class DatabaseTestClient(_DatabaseTestClient):
     """
-    Adaption of DatabaseTestClient for saffier.
+    Native SQLAlchemy Async test database client for Saffier.
 
-    Note: the default of lazy_setup is True here. This enables the simple Registry syntax.
+    The public test-client entry point enables lazy setup by default so it works
+    cleanly with the simple ``Registry(database=DatabaseTestClient(...))`` test
+    pattern. All database creation and teardown still happens in the base
+    SQLAlchemy-backed implementation.
     """
 
     testclient_default_test_prefix: str = default_test_prefix
@@ -54,7 +65,14 @@ class DatabaseTestClient(_DatabaseTestClient):
         drop_database: bool = default_drop_database,
         test_prefix: str = default_test_prefix,
         **options: Any,
-    ):
+    ) -> None:
+        """Initialize the SQLAlchemy-backed test client with public defaults.
+
+        Environment-driven defaults are resolved at module import time and then
+        passed to the runtime implementation. The wrapper exists to preserve the
+        public ``saffier.testclient.DatabaseTestClient`` API while avoiding a
+        second implementation of test database management.
+        """
         super().__init__(
             url,
             use_existing=use_existing,

--- a/scripts/check
+++ b/scripts/check
@@ -10,6 +10,6 @@ export SOURCE_FILES="saffier tests"
 export EXCLUDE=__init__.py
 export MAIN="saffier"
 
-${PREFIX}ty check $MAIN
-${PREFIX}ruff check $SOURCE_FILES --line-length 99
-${PREFIX}ruff format $SOURCE_FILES --check
+"${PREFIX}ty" check $MAIN
+"${PREFIX}ruff" check $SOURCE_FILES --line-length 99
+"${PREFIX}ruff" format $SOURCE_FILES --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -11,5 +11,5 @@ export EXCLUDE=__init__.py
 
 set -x
 
-${PREFIX}ruff check $SOURCE_FILES --fix --line-length 99
-${PREFIX}ruff format $SOURCE_FILES
+"${PREFIX}ruff" check $SOURCE_FILES --fix --line-length 99
+"${PREFIX}ruff" format $SOURCE_FILES

--- a/tests/cli/test_shell_modules.py
+++ b/tests/cli/test_shell_modules.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import types
 from types import SimpleNamespace
 
@@ -201,7 +202,20 @@ async def test_run_shell_branches(monkeypatch: pytest.MonkeyPatch):
 
         return _Ctx()
 
-    monkeypatch.setattr(shell_base.nest_asyncio, "apply", lambda: events.append("nest"))
+    @contextlib.contextmanager
+    def fake_shell_loop_reentry():
+        """Record shell loop re-entry without mutating asyncio in this unit test.
+
+        The production helper temporarily allows the active event loop to be
+        re-entered while IPython or ptpython owns the terminal. This fake keeps
+        the branch coverage focused on shell orchestration while still proving
+        the scoped helper is invoked.
+        """
+
+        events.append("reentry")
+        yield
+
+    monkeypatch.setattr(shell_base, "_shell_loop_reentry", fake_shell_loop_reentry)
     monkeypatch.setattr(
         shell_base,
         "get_ipython",
@@ -235,5 +249,6 @@ async def test_run_shell_branches(monkeypatch: pytest.MonkeyPatch):
         app=object(), lifespan=fake_lifespan, registry=_DummyRegistry(), kernel="ptpython"
     )
     assert events.count("enter") == 2
+    assert events.count("reentry") == 2
     assert "ipython" in events
     assert "ptpython" in events

--- a/tests/registry/test_registry_run_sync.py
+++ b/tests/registry/test_registry_run_sync.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 import saffier
-from saffier.core.utils.sync import weak_subloop_map
+from saffier.core.utils.sync import force_current_loop_for_sqlalchemy, weak_subloop_map
 from saffier.testclient import DatabaseTestClient as Database
 from tests.settings import DATABASE_URL
 
@@ -86,3 +86,36 @@ def test_stack():
     gc.collect()
     time.sleep(1)
     assert len(weak_subloop_map) <= initial
+
+
+@pytest.mark.anyio
+async def test_run_sync_reentry_restores_asyncio_loop_state():
+    """Ensure loop re-entry does not poison later asyncio callbacks.
+
+    Python 3.14 requires ``asyncio.timeout()`` to run while
+    ``asyncio.current_task()`` is visible. The SQLAlchemy-bound sync bridge
+    temporarily re-enters the running loop for deferred ORM loads, and this
+    regression test proves that the loop is returned to normal before the next
+    regular async callback executes.
+    """
+
+    async def use_timeout() -> str:
+        """Exercise the asyncio timeout path used by asyncpg connections.
+
+        The coroutine intentionally does no database I/O. It isolates the
+        Python 3.14 event-loop invariant that failed after a permanent nested
+        loop patch had been installed.
+        """
+
+        async with asyncio.timeout(1):
+            await asyncio.sleep(0)
+        return "ready"
+
+    loop = asyncio.get_running_loop()
+
+    with force_current_loop_for_sqlalchemy():
+        assert saffier.run_sync(use_timeout()) == "ready"
+
+    assert not hasattr(loop.__class__, "_nest_patched")
+    async with asyncio.timeout(1):
+        await asyncio.sleep(0)

--- a/tests/registry/test_registry_run_sync.py
+++ b/tests/registry/test_registry_run_sync.py
@@ -94,21 +94,28 @@ async def test_run_sync_reentry_restores_asyncio_loop_state():
 
     Python 3.14 requires ``asyncio.timeout()`` to run while
     ``asyncio.current_task()`` is visible. The SQLAlchemy-bound sync bridge
-    temporarily re-enters the running loop for deferred ORM loads, and this
-    regression test proves that the loop is returned to normal before the next
-    regular async callback executes.
+    temporarily re-enters the running loop for deferred ORM loads. Python 3.10
+    does not expose ``asyncio.timeout()``, so the fallback path still proves the
+    loop class is restored after re-entry while newer runtimes also exercise the
+    stricter timeout/current-task invariant.
     """
 
     async def use_timeout() -> str:
-        """Exercise the asyncio timeout path used by asyncpg connections.
+        """Exercise the best timeout primitive available on this Python.
 
-        The coroutine intentionally does no database I/O. It isolates the
-        Python 3.14 event-loop invariant that failed after a permanent nested
-        loop patch had been installed.
+        Python 3.11 and newer use ``asyncio.timeout()``, which is the code path
+        asyncpg reaches on Python 3.14 and the source of the reported failure.
+        Python 3.10 falls back to ``asyncio.wait_for()`` so the same test keeps
+        validating that Saffier removes the temporary nested-loop patch before
+        regular async execution resumes.
         """
 
-        async with asyncio.timeout(1):
-            await asyncio.sleep(0)
+        timeout_context = getattr(asyncio, "timeout", None)
+        if timeout_context is None:
+            await asyncio.wait_for(asyncio.sleep(0), timeout=1)
+        else:
+            async with timeout_context(1):
+                await asyncio.sleep(0)
         return "ready"
 
     loop = asyncio.get_running_loop()
@@ -117,5 +124,4 @@ async def test_run_sync_reentry_restores_asyncio_loop_state():
         assert saffier.run_sync(use_timeout()) == "ready"
 
     assert not hasattr(loop.__class__, "_nest_patched")
-    async with asyncio.timeout(1):
-        await asyncio.sleep(0)
+    assert await use_timeout() == "ready"


### PR DESCRIPTION
Remove Databasez from the runtime dependency path and route Saffier database execution, transactions, schema helpers, and lifecycle management through SQLAlchemy 2.x async APIs. Update docs and release metadata for 2.2.0.